### PR TITLE
Bugfix: Ensure findMainUrlsFile identifies the correct file by checking for settings.py with urls.py

### DIFF
--- a/src/djangoProjectAnalyzer.ts
+++ b/src/djangoProjectAnalyzer.ts
@@ -70,7 +70,7 @@ export class DjangoProjectAnalyzer {
     const dirs = await this.getDirectories(projectRoot);
     for (const dir of dirs) {
       const urlsPath = path.join(dir, 'urls.py');
-      if (fs.existsSync(urlsPath)) {
+      if (fs.existsSync(urlsPath) && fs.existsSync(path.join(dir, 'settings.py'))) {
         // Verificar si es el urls.py principal (contiene ROOT_URLCONF o urlpatterns)
         const content = await readFile(urlsPath, 'utf8');
         if (content.includes('ROOT_URLCONF') || content.includes('urlpatterns')) {

--- a/src/djangoProjectAnalyzer.ts
+++ b/src/djangoProjectAnalyzer.ts
@@ -30,6 +30,7 @@ export interface DjangoUrl {
   pattern: string;
   viewName: string;
   lineNumber: number;
+  path: string;
 }
 
 export interface DjangoAdminClass {
@@ -566,7 +567,8 @@ export class DjangoProjectAnalyzer {
           urls.push({
             pattern: pattern,
             viewName: match[2],
-            lineNumber: i
+            lineNumber: i,
+            path: urlsPath
           });
           continue;
         }

--- a/src/djangoStructureProvider.ts
+++ b/src/djangoStructureProvider.ts
@@ -328,9 +328,9 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
         {
           command: 'djangoStructureExplorer.openFile',
           title: 'Open URL',
-          arguments: [urlsPath, url.lineNumber]
+          arguments: [url.path, url.lineNumber]
         },
-        vscode.Uri.file(urlsPath),
+        vscode.Uri.file(url.path),
         'url'
       );
       urlItem.description = url.viewName;


### PR DESCRIPTION
findMainUrlsFile was returning the first directory containing a urls.py in alphabetical order.  The main urls.py is the one in the directory containing settings.py.