### PR TITLE
Robustez y cobertura de parsing del Django Structure Explorer

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": "./out/test/setup.js",
+  "spec": "./out/test/**/*.test.js",
+  "timeout": 10000
+}

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
-    "test": "node ./out/test/runTest.js"
+    "test": "mocha"
   },
   "devDependencies": {
     "@types/glob": "^7.1.3",

--- a/src/djangoOutlineProvider.ts
+++ b/src/djangoOutlineProvider.ts
@@ -21,11 +21,17 @@ export class DjangoOutlineProvider implements vscode.DocumentSymbolProvider {
       return [];
     }
 
+    // Respetar la cancelación antes de empezar a analizar.
+    if (token.isCancellationRequested) {
+      return [];
+    }
+
     try {
       // Analizar el archivo según su tipo
       if (fileName === 'models.py') {
         const models = await this.analyzer.extractModels(document.fileName);
         for (const model of models) {
+          if (token.isCancellationRequested) { break; }
           const modelSymbol = new vscode.DocumentSymbol(
             model.name,
             'class',
@@ -53,6 +59,7 @@ export class DjangoOutlineProvider implements vscode.DocumentSymbolProvider {
       } else if (fileName === 'views.py') {
         const views = await this.analyzer.extractViews(document.fileName);
         for (const view of views) {
+          if (token.isCancellationRequested) { break; }
           const viewSymbol = new vscode.DocumentSymbol(
             view.name,
             view.isClass ? 'class' : 'function',
@@ -65,6 +72,7 @@ export class DjangoOutlineProvider implements vscode.DocumentSymbolProvider {
       } else if (fileName === 'urls.py') {
         const urls = await this.analyzer.extractUrls(document.fileName);
         for (const url of urls) {
+          if (token.isCancellationRequested) { break; }
           const urlSymbol = new vscode.DocumentSymbol(
             url.pattern,
             url.viewName,
@@ -77,6 +85,7 @@ export class DjangoOutlineProvider implements vscode.DocumentSymbolProvider {
       } else if (fileName === 'admin.py') {
         const adminClasses = await this.analyzer.extractAdminClasses(document.fileName);
         for (const adminClass of adminClasses) {
+          if (token.isCancellationRequested) { break; }
           const adminSymbol = new vscode.DocumentSymbol(
             adminClass.name,
             `Admin for ${adminClass.modelName}`,

--- a/src/djangoProjectAnalyzer.ts
+++ b/src/djangoProjectAnalyzer.ts
@@ -5,7 +5,29 @@ import * as util from 'util';
 
 const readFile = util.promisify(fs.readFile);
 const readdir = util.promisify(fs.readdir);
-const stat = util.promisify(fs.stat);
+
+/**
+ * Comprueba de forma asíncrona si una ruta existe, sin bloquear el event loop.
+ * Reemplaza a fs.existsSync (síncrono) dentro del árbol asíncrono.
+ */
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.promises.access(targetPath, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Registra un error y lo notifica al usuario, en lugar de tragárselo en silencio.
+ * Así se distingue "no hay resultados" de "el parseo falló".
+ */
+function reportError(context: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`${context}: ${message}`);
+  vscode.window.showErrorMessage(`Django Structure Explorer: ${context}. ${message}`);
+}
 
 export interface DjangoModel {
   name: string;
@@ -45,24 +67,24 @@ export interface DjangoSetting {
 }
 
 export class DjangoProjectAnalyzer {
-  
+
   /**
    * Busca todos los archivos settings.py en el proyecto
    */
   async findSettingsFiles(projectRoot: string): Promise<string[]> {
     const settingsFiles: string[] = [];
-    
+
     const dirs = await this.getDirectories(projectRoot);
     for (const dir of dirs) {
       const settingsPath = path.join(dir, 'settings.py');
-      if (fs.existsSync(settingsPath)) {
+      if (await pathExists(settingsPath)) {
         settingsFiles.push(settingsPath);
       }
     }
-    
+
     return settingsFiles;
   }
-  
+
   /**
    * Busca el archivo urls.py principal del proyecto
    */
@@ -70,7 +92,7 @@ export class DjangoProjectAnalyzer {
     const dirs = await this.getDirectories(projectRoot);
     for (const dir of dirs) {
       const urlsPath = path.join(dir, 'urls.py');
-      if (fs.existsSync(urlsPath)) {
+      if (await pathExists(urlsPath)) {
         // Verificar si es el urls.py principal (contiene ROOT_URLCONF o urlpatterns)
         const content = await readFile(urlsPath, 'utf8');
         if (content.includes('ROOT_URLCONF') || content.includes('urlpatterns')) {
@@ -78,106 +100,103 @@ export class DjangoProjectAnalyzer {
         }
       }
     }
-    
+
     return undefined;
   }
-  
+
   /**
    * Busca todas las aplicaciones Django en el proyecto
    */
   async findDjangoApps(projectRoot: string): Promise<string[]> {
     const apps: string[] = [];
     const dirs = await this.getDirectories(projectRoot);
-    
+
     for (const dir of dirs) {
       // Verificar si es una aplicación Django (contiene apps.py o models.py)
       const appsPyPath = path.join(dir, 'apps.py');
       const modelsPyPath = path.join(dir, 'models.py');
-      
-      if (fs.existsSync(appsPyPath) || fs.existsSync(modelsPyPath)) {
+
+      if (await pathExists(appsPyPath) || await pathExists(modelsPyPath)) {
         apps.push(dir);
       }
     }
-    
+
     return apps;
   }
-  
+
   /**
    * Extrae los modelos de un archivo models.py
    */
   async extractModels(modelsPath: string): Promise<DjangoModel[]> {
     const models: DjangoModel[] = [];
-    
+
     try {
       const content = await readFile(modelsPath, 'utf8');
       const lines = content.split('\n');
-      
+
       // Analizar las importaciones para detectar alias de models o importaciones directas
       const importAliases: {[key: string]: string} = {};
       const directImports: string[] = [];
-      
+
       // Buscar importaciones como "from django.db import models" o "from django.db.models import CharField, TextField"
       for (let i = 0; i < 30 && i < lines.length; i++) { // Revisar solo las primeras líneas
         const line = lines[i].trim();
-        
+
         // Detectar alias de models
         const aliasMatch = line.match(/^from\s+django\.db\s+import\s+models\s+as\s+(\w+)/);
         if (aliasMatch) {
           importAliases['models'] = aliasMatch[1];
-          console.log(`Detectado alias para models: ${aliasMatch[1]}`);
         }
-        
+
         // Detectar importaciones directas de tipos de campo
         const directImportMatch = line.match(/^from\s+django\.db\.models\s+import\s+(.+)$/);
         if (directImportMatch) {
           const imports = directImportMatch[1].split(',').map(i => i.trim());
           directImports.push(...imports);
-          console.log(`Detectadas importaciones directas: ${imports.join(', ')}`);
         }
       }
-      
+
       // Almacenar las clases base importadas que podrían ser modelos
       const importedBaseClasses: {[key: string]: string} = {};
-      
+
       // Buscar importaciones de clases base personalizadas
       for (let i = 0; i < 30 && i < lines.length; i++) {
         const line = lines[i].trim();
-        
+
         // Detectar importaciones de clases base
         const baseClassMatch = line.match(/^from\s+([\w.]+)\s+import\s+([\w,\s]+)$/);
         if (baseClassMatch) {
           const module = baseClassMatch[1];
           const imports = baseClassMatch[2].split(',').map(i => i.trim());
-          
+
           imports.forEach(importName => {
             importedBaseClasses[importName] = module;
-            console.log(`Detectada posible clase base: ${importName} desde ${module}`);
           });
         }
       }
-      
+
       // Función para verificar si una clase base es un modelo Django basado en importaciones
       const isDjangoModel = (baseClass: string): boolean => {
         // Casos directos
         if (baseClass === 'models.Model' || baseClass === 'Model') {
           return true;
         }
-        
+
         // Verificar clases importadas
         const cleanBase = baseClass.trim();
         if (importedBaseClasses[cleanBase]) {
           const module = importedBaseClasses[cleanBase];
-          return module.includes('django.db.models') || 
+          return module.includes('django.db.models') ||
                  module.includes('django.contrib.gis.db.models') ||
                  module.endsWith('.models');
         }
-        
+
         return false;
       };
-      
+
       // Mantener un registro de las clases que son modelos
       const modelClasses = new Set<string>();
-      
+
       // Lista de clases base comunes que indican que es un modelo
       const modelBaseClasses = [
         'Model',
@@ -199,19 +218,19 @@ export class DjangoProjectAnalyzer {
         'AbstractModel',
         'AbstractBaseModel'
       ];
-      
+
       // Primera pasada: identificar todas las clases que heredan directamente de Model o clases base conocidas
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i].trim();
         if (line.startsWith('class ')) {
-          const classMatch = line.match(/^class\s+(\w+)\s*\(([^)]+)\)/);          
+          const classMatch = line.match(/^class\s+(\w+)\s*\(([^)]+)\)/);
           if (classMatch) {
             const className = classMatch[1];
             const baseClasses = classMatch[2].split(',').map(c => c.trim());
-            
+
             // Verificar si hereda de alguna clase base conocida explícitamente o a través de importación
-            if (baseClasses.some(base => 
-              modelBaseClasses.includes(base.split('.')?.pop() || base) || 
+            if (baseClasses.some(base =>
+              modelBaseClasses.includes(base.split('.')?.pop() || base) ||
               isDjangoModel(base)
             )) {
               modelClasses.add(className);
@@ -219,7 +238,7 @@ export class DjangoProjectAnalyzer {
           }
         }
       }
-      
+
       // Segunda pasada: identificar clases que heredan de modelos ya identificados
       let newModelsFound = true;
       while (newModelsFound) {
@@ -227,7 +246,7 @@ export class DjangoProjectAnalyzer {
         for (let i = 0; i < lines.length; i++) {
           const line = lines[i].trim();
           if (line.startsWith('class ')) {
-            const classMatch = line.match(/^class\s+(\w+)\s*\(([^)]+)\)/);            
+            const classMatch = line.match(/^class\s+(\w+)\s*\(([^)]+)\)/);
             if (classMatch) {
               const className = classMatch[1];
               if (!modelClasses.has(className)) {
@@ -242,14 +261,14 @@ export class DjangoProjectAnalyzer {
           }
         }
       }
-      
+
       // Expresión regular para encontrar el inicio de una clase
       const classRegex = /^class\s+(\w+)\s*\(/;
       // Expresión regular para encontrar el inicio de la clase Meta
       const metaClassRegex = /^\s+class\s+Meta\s*:/;
       // Expresión regular para detectar decoradores @property
       const propertyDecoratorRegex = /^\s*@property\s*$/;
-      
+
       let currentModel: DjangoModel | null = null;
       let inModelDefinition = false;
       let inMetaClass = false;
@@ -260,18 +279,18 @@ export class DjangoProjectAnalyzer {
       let currentFieldLine = 0;
       let parenthesesCount = 0; // Para rastrear paréntesis abiertos/cerrados
       let isPropertyMethod = false; // Para rastrear si el próximo método tiene el decorador @property
-      
+
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
         const indentMatch = line.match(/^(\s*)/);
         const indentation = indentMatch ? indentMatch[1].length : 0;
-        
+
         // Detectar decorador @property
         if (line.trim().match(propertyDecoratorRegex)) {
           isPropertyMethod = true;
           continue;
         }
-        
+
         // Detectar una nueva clase
         const classMatch = line.match(classRegex);
         if (classMatch && modelClasses.has(classMatch[1])) {
@@ -279,14 +298,14 @@ export class DjangoProjectAnalyzer {
           if (currentModel) {
             models.push(currentModel);
           }
-          
+
           // Crear un nuevo modelo
           currentModel = {
             name: classMatch[1],
             lineNumber: i,
             fields: []
           };
-          
+
           // Iniciar el seguimiento de la definición del modelo
           inModelDefinition = true;
           inMetaClass = false;
@@ -294,25 +313,25 @@ export class DjangoProjectAnalyzer {
           isPropertyMethod = false;
           continue;
         }
-        
+
         // Si no estamos dentro de un modelo, continuar
         if (!currentModel || !inModelDefinition) {
           isPropertyMethod = false;
           continue;
         }
-        
+
         // Si es una línea vacía, continuar
         if (line.trim() === '') {
           continue;
         }
-        
+
         // Detectar si estamos entrando en la clase Meta
         if (line.match(metaClassRegex)) {
           inMetaClass = true;
           isPropertyMethod = false;
           continue;
         }
-        
+
         // Si la indentación es menor o igual a la de la clase, hemos salido del modelo
         if (indentation <= classIndentation && line.trim() !== '') {
           // Guardar el modelo actual
@@ -323,12 +342,12 @@ export class DjangoProjectAnalyzer {
           isPropertyMethod = false;
           continue;
         }
-        
+
         // Ignorar líneas dentro de la clase Meta
         if (inMetaClass) {
           continue;
         }
-        
+
         // Detectar método con decorador @property
         const methodMatch = line.match(/^\s+def\s+(\w+)\s*\(/);
         if (isPropertyMethod && methodMatch) {
@@ -341,24 +360,24 @@ export class DjangoProjectAnalyzer {
           isPropertyMethod = false;
           continue;
         }
-        
+
         // Construir expresión regular para detectar campos considerando alias e importaciones directas
         let fieldRegexPatterns = [
           // Patrón estándar: name = models.CharField(...)
           `^\\s+(\\w+)\\s*=\\s*models\\.(\\w+)\\s*\\(?(.*)`
         ];
-        
+
         // Añadir patrón para alias: name = m.CharField(...)
         if (importAliases['models']) {
-          fieldRegexPatterns.push(`^\\s+(\\w+)\\s*=\\s*${importAliases['models']}\\.(\\w+)\\s*\\(?(.*)`)
+          fieldRegexPatterns.push(`^\\s+(\\w+)\\s*=\\s*${importAliases['models']}\\.(\\w+)\\s*\\(?(.*)`);
         }
-        
+
         // Añadir patrón para importaciones directas: name = CharField(...)
         if (directImports.length > 0) {
           const directImportsPattern = directImports.join('|');
           fieldRegexPatterns.push(`^\\s+(\\w+)\\s*=\\s*(${directImportsPattern})\\s*\\(?(.*)`);
         }
-        
+
         // Intentar cada patrón
         let fieldMatch = null;
         let matchedPattern = '';
@@ -371,7 +390,7 @@ export class DjangoProjectAnalyzer {
             break;
           }
         }
-        
+
         if (fieldMatch) {
           // Si estábamos procesando un campo anterior, añadirlo al modelo
           if (currentFieldName && currentFieldType) {
@@ -381,10 +400,10 @@ export class DjangoProjectAnalyzer {
               lineNumber: currentFieldLine
             });
           }
-          
+
           // Iniciar el seguimiento de un nuevo campo
           currentFieldName = fieldMatch[1];
-          
+
           // El tipo de campo depende del patrón que coincidió
           if (matchedPattern.includes('(\\w+)\\.(\\w+)')) {
             // Patrón con prefijo (models.CharField o alias.CharField)
@@ -393,15 +412,15 @@ export class DjangoProjectAnalyzer {
             // Patrón de importación directa (CharField)
             currentFieldType = fieldMatch[2];
           }
-          
+
           currentFieldLine = i;
           fieldStartIndentation = indentation;
-          
+
           // Contar paréntesis abiertos y cerrados en esta línea
           const openParens = (fieldMatch[fieldMatch.length - 1].match(/\(/g) || []).length;
           const closeParens = (fieldMatch[fieldMatch.length - 1].match(/\)/g) || []).length;
           parenthesesCount = openParens - closeParens;
-          
+
           // Si los paréntesis están equilibrados, el campo está completo en esta línea
           if (parenthesesCount === 0) {
             currentModel.fields!.push({
@@ -419,7 +438,7 @@ export class DjangoProjectAnalyzer {
           const openParens = (line.match(/\(/g) || []).length;
           const closeParens = (line.match(/\)/g) || []).length;
           parenthesesCount += openParens - closeParens;
-          
+
           // Si los paréntesis están equilibrados, el campo está completo
           if (parenthesesCount === 0) {
             currentModel.fields!.push({
@@ -436,7 +455,7 @@ export class DjangoProjectAnalyzer {
           // Verificar si es un nuevo campo con cualquier formato no capturado anteriormente
           const otherFieldRegex = /^\s+(\w+)\s*=\s*(\w+)(?:\.(\w+))?\s*\(?(.*)/;
           const otherFieldMatch = line.match(otherFieldRegex);
-          
+
           if (otherFieldMatch) {
             // Si estábamos procesando un campo anterior, añadirlo al modelo
             if (currentFieldName && currentFieldType) {
@@ -446,18 +465,18 @@ export class DjangoProjectAnalyzer {
                 lineNumber: currentFieldLine
               });
             }
-            
+
             // Iniciar el seguimiento de un nuevo campo
             currentFieldName = otherFieldMatch[1];
             // El tipo de campo puede ser con o sin prefijo
             currentFieldType = otherFieldMatch[3] || otherFieldMatch[2];
             currentFieldLine = i;
-            
+
             // Contar paréntesis abiertos y cerrados en esta línea
             const openParens = (otherFieldMatch[4].match(/\(/g) || []).length;
             const closeParens = (otherFieldMatch[4].match(/\)/g) || []).length;
             parenthesesCount = openParens - closeParens;
-            
+
             // Si los paréntesis están equilibrados, el campo está completo en esta línea
             if (parenthesesCount === 0) {
               currentModel.fields!.push({
@@ -471,7 +490,7 @@ export class DjangoProjectAnalyzer {
           }
         }
       }
-      
+
       // Añadir el último campo si existe
       if (currentFieldName && currentFieldType && currentModel) {
         currentModel.fields!.push({
@@ -480,39 +499,34 @@ export class DjangoProjectAnalyzer {
           lineNumber: currentFieldLine
         });
       }
-      
+
       // Añadir el último modelo si existe
       if (currentModel) {
         models.push(currentModel);
       }
-      
-      console.log(`Modelos extraídos: ${models.length}`);
-      for (const model of models) {
-        console.log(`Modelo: ${model.name}, Campos: ${model.fields?.length || 0}`);
-      }
-      
+
     } catch (error) {
-      console.error(`Error al analizar modelos: ${error}`);
+      reportError('Error al analizar modelos', error);
     }
-    
+
     return models;
   }
-  
+
   /**
    * Extrae las vistas de un archivo views.py
    */
   async extractViews(viewsPath: string): Promise<DjangoView[]> {
     const views: DjangoView[] = [];
-    
+
     try {
       const content = await readFile(viewsPath, 'utf8');
       const lines = content.split('\n');
-      
+
       // Expresión regular para encontrar funciones de vista
       const functionViewRegex = /^def\s+(\w+)\s*\(/;
       // Expresión regular para encontrar clases de vista
       const classViewRegex = /^class\s+(\w+)\s*\(/;
-      
+
       for (let i = 0; i < lines.length; i++) {
         const functionMatch = lines[i].match(functionViewRegex);
         if (functionMatch) {
@@ -523,7 +537,7 @@ export class DjangoProjectAnalyzer {
           });
           continue;
         }
-        
+
         const classMatch = lines[i].match(classViewRegex);
         if (classMatch) {
           views.push({
@@ -534,30 +548,30 @@ export class DjangoProjectAnalyzer {
         }
       }
     } catch (error) {
-      console.error(`Error al analizar vistas: ${error}`);
+      reportError('Error al analizar vistas', error);
     }
-    
+
     return views;
   }
-  
+
   /**
    * Extrae las URLs de un archivo urls.py
    */
   async extractUrls(urlsPath: string, prefix: string = ''): Promise<DjangoUrl[]> {
     const urls: DjangoUrl[] = [];
-    
+
     try {
       const content = await readFile(urlsPath, 'utf8');
       const lines = content.split('\n');
-      
+
       // Expresiones regulares para encontrar patrones de URL
       const pathRegex = /path\s*\(\s*['"]([^'"]+)['"]\s*,\s*(\w+(?:\.\w+)*)/;
       const rePathRegex = /re_path\s*\(\s*['"]([^'"]+)['"]\s*,\s*(\w+(?:\.\w+)*)/;
       const urlRegex = /url\s*\(\s*['"]([^'"]+)['"]\s*,\s*(\w+(?:\.\w+)*)/;
-      
+
       // Expresión regular para encontrar includes
       const includeRegex = /include\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*['"]([^'"]+)['"]\s*)?\)/;
-      
+
       for (let i = 0; i < lines.length; i++) {
         // Buscar patrones de URL directos
         let match = lines[i].match(pathRegex) || lines[i].match(rePathRegex) || lines[i].match(urlRegex);
@@ -570,33 +584,33 @@ export class DjangoProjectAnalyzer {
           });
           continue;
         }
-        
+
         // Buscar includes
         const includeMatch = lines[i].match(includeRegex);
         if (includeMatch) {
           const includedModule = includeMatch[1];
           const includePrefix = includeMatch[2] || '';
-          
+
           // Determinar la ruta del archivo incluido
           let includedFilePath = '';
           if (includedModule.endsWith('.urls')) {
             // Convertir formato de módulo a ruta de archivo
             const parts = includedModule.split('.');
             const appName = parts[0];
-            
+
             // Buscar la aplicación en el proyecto
             const projectRoot = path.dirname(path.dirname(urlsPath));
             const appPath = path.join(projectRoot, appName);
-            
-            if (fs.existsSync(appPath)) {
+
+            if (await pathExists(appPath)) {
               includedFilePath = path.join(appPath, 'urls.py');
             }
           }
-          
-          if (includedFilePath && fs.existsSync(includedFilePath)) {
+
+          if (includedFilePath && await pathExists(includedFilePath)) {
             // Combinar prefijos
             const newPrefix = prefix + (includePrefix ? includePrefix : '');
-            
+
             // Extraer URLs del archivo incluido con el prefijo actualizado
             const includedUrls = await this.extractUrls(includedFilePath, newPrefix);
             urls.push(...includedUrls);
@@ -604,21 +618,21 @@ export class DjangoProjectAnalyzer {
         }
       }
     } catch (error) {
-      console.error(`Error al analizar URLs: ${error}`);
+      reportError('Error al analizar URLs', error);
     }
-    
+
     return urls;
   }
-  
+
   /**
    * Extrae las clases de admin de un archivo admin.py
    */
   async extractAdminClasses(adminPath: string): Promise<DjangoAdminClass[]> {
     const adminClasses: DjangoAdminClass[] = [];
-    
+
     try {
       const content = await readFile(adminPath, 'utf8');
-      
+
       // Buscar todas las clases de admin
       const classRegex = /class\s+(\w+)\s*\(\s*(?:admin\.)?(\w+Admin|TabularInline|StackedInline)\s*\)/g;
       let classMatch;
@@ -628,7 +642,7 @@ export class DjangoProjectAnalyzer {
           lineNumber: content.substring(0, classMatch.index).split('\n').length - 1,
           modelName: ''
         };
-        
+
         // Buscar el modelo asociado
         const modelRegex = new RegExp(`model\\s*=\\s*(\\w+)`, 'g');
         const modelContent = content.substring(classMatch.index, content.length);
@@ -636,101 +650,101 @@ export class DjangoProjectAnalyzer {
         if (modelMatch) {
           adminClass.modelName = modelMatch[1];
         }
-        
+
         adminClasses.push(adminClass);
       }
-      
+
       // Buscar registros directos con admin.site.register
       const registerRegex = /admin\.site\.register\s*\(\s*(\w+)(?:\s*,\s*(\w+))?\s*\)/g;
       let registerMatch;
       while ((registerMatch = registerRegex.exec(content)) !== null) {
         const modelName = registerMatch[1];
         const adminClassName = registerMatch[2] || 'ModelAdmin';
-        
+
         adminClasses.push({
           name: adminClassName,
           lineNumber: content.substring(0, registerMatch.index).split('\n').length - 1,
           modelName: modelName
         });
       }
-      
+
       // Buscar decoradores de register
       const decoratorRegex = /@admin\.register\s*\(\s*(\w+)\s*\)\s*\n+\s*class\s+(\w+)/g;
       let decoratorMatch;
       while ((decoratorMatch = decoratorRegex.exec(content)) !== null) {
         const modelName = decoratorMatch[1];
         const adminClassName = decoratorMatch[2];
-        
+
         adminClasses.push({
           name: adminClassName,
           lineNumber: content.substring(0, decoratorMatch.index).split('\n').length - 1,
           modelName: modelName
         });
       }
-      
+
     } catch (error) {
-      console.error(`Error al analizar clases de admin: ${error}`);
+      reportError('Error al analizar clases de admin', error);
     }
-    
+
     return adminClasses;
   }
-  
+
   /**
    * Extrae las variables definidas en un archivo settings.py
    */
   async extractSettings(settingsPath: string): Promise<DjangoSetting[]> {
     const settings: DjangoSetting[] = [];
-    
+
     try {
       const content = await readFile(settingsPath, 'utf8');
       const lines = content.split('\n');
-      
+
       // Expresión regular para encontrar definiciones de variables
       const settingRegex = /^([A-Z_][A-Z0-9_]*)\s*=\s*(.+)$/;
-      
+
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i].trim();
-        
+
         // Ignorar comentarios y líneas vacías
         if (line.startsWith('#') || line === '') {
           continue;
         }
-        
+
         const match = line.match(settingRegex);
         if (match) {
           let value = match[2].trim();
-          
+
           // Eliminar comentarios al final de la línea
           const commentIndex = value.indexOf('#');
           if (commentIndex > 0) {
             value = value.substring(0, commentIndex).trim();
           }
-          
+
           // Manejar valores multilínea
-          if ((value.includes('{') && !value.includes('}')) || 
+          if ((value.includes('{') && !value.includes('}')) ||
               (value.includes('[') && !value.includes(']')) ||
               (value.includes('(') && !value.includes(')'))) {
-            
+
             // Buscar el final de la definición multilínea
             let j = i + 1;
             let multilineValue = value;
-            
+
             while (j < lines.length) {
               const nextLine = lines[j].trim();
               multilineValue += ' ' + nextLine;
-              
-              if ((value.includes('{') && nextLine.includes('}')) || 
+
+              if ((value.includes('{') && nextLine.includes('}')) ||
                   (value.includes('[') && nextLine.includes(']')) ||
                   (value.includes('(') && nextLine.includes(')'))) {
                 break;
               }
-              
+
               j++;
             }
-            
+
             value = multilineValue;
           }
-          
+
           settings.push({
             name: match[1],
             value: value,
@@ -739,36 +753,54 @@ export class DjangoProjectAnalyzer {
         }
       }
     } catch (error) {
-      console.error(`Error al analizar settings: ${error}`);
+      reportError('Error al analizar settings', error);
     }
-    
+
     return settings;
   }
-  
+
   /**
-   * Obtiene todos los directorios en un directorio dado
+   * Obtiene todos los directorios en un directorio dado, de forma recursiva.
+   * Limita la profundidad y excluye directorios pesados (entornos virtuales,
+   * dependencias) para evitar congelar VS Code en proyectos grandes.
    */
-  private async getDirectories(dir: string): Promise<string[]> {
+  private async getDirectories(dir: string, depth: number = 0): Promise<string[]> {
     const dirs: string[] = [];
-    
+    const MAX_DEPTH = 6;
+    const EXCLUDED_DIRS = new Set<string>([
+      'node_modules', 'venv', '.venv', 'env', 'site-packages',
+      '.git', '.tox', '.mypy_cache', '.pytest_cache', 'migrations'
+    ]);
+
+    if (depth > MAX_DEPTH) {
+      return dirs;
+    }
+
     try {
       const entries = await readdir(dir, { withFileTypes: true });
-      
+
       for (const entry of entries) {
         const fullPath = path.join(dir, entry.name);
-        
-        if (entry.isDirectory() && !entry.name.startsWith('.') && !entry.name.startsWith('__')) {
+
+        if (
+          entry.isDirectory() &&
+          !entry.name.startsWith('.') &&
+          !entry.name.startsWith('__') &&
+          !EXCLUDED_DIRS.has(entry.name)
+        ) {
           dirs.push(fullPath);
-          
+
           // Recursivamente buscar en subdirectorios
-          const subdirs = await this.getDirectories(fullPath);
+          const subdirs = await this.getDirectories(fullPath, depth + 1);
           dirs.push(...subdirs);
         }
       }
     } catch (error) {
+      // La travesía de directorios puede toparse con rutas sin permisos;
+      // se registra pero no se interrumpe ni se molesta al usuario.
       console.error(`Error al leer directorios: ${error}`);
     }
-    
+
     return dirs;
   }
 }

--- a/src/djangoProjectAnalyzer.ts
+++ b/src/djangoProjectAnalyzer.ts
@@ -281,6 +281,21 @@ export class DjangoProjectAnalyzer {
       let parenthesesCount = 0; // Para rastrear paréntesis abiertos/cerrados
       let isPropertyMethod = false; // Para rastrear si el próximo método tiene el decorador @property
 
+      // Patrones de campo compilados UNA sola vez (no dependen de la línea).
+      // El último grupo captura el paréntesis de apertura (`\(?` dentro del grupo)
+      // para que el conteo de paréntesis cuente tanto `(` como `)`. El tipo de campo
+      // es siempre el grupo 2 tanto en patrones con prefijo como en importación directa.
+      const fieldPatterns: RegExp[] = [
+        new RegExp(`^\\s+(\\w+)\\s*=\\s*models\\.(\\w+)\\s*(\\(?.*)`)
+      ];
+      if (importAliases['models']) {
+        fieldPatterns.push(new RegExp(`^\\s+(\\w+)\\s*=\\s*${importAliases['models']}\\.(\\w+)\\s*(\\(?.*)`));
+      }
+      if (directImports.length > 0) {
+        const directImportsPattern = directImports.join('|');
+        fieldPatterns.push(new RegExp(`^\\s+(\\w+)\\s*=\\s*(${directImportsPattern})\\s*(\\(?.*)`));
+      }
+
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
         const indentMatch = line.match(/^(\s*)/);
@@ -371,35 +386,12 @@ export class DjangoProjectAnalyzer {
         }
 
         // Construir expresión regular para detectar campos considerando alias e importaciones directas
-        // El último grupo captura el paréntesis de apertura (`\(?` DENTRO del grupo),
-        // de modo que el conteo de paréntesis cuente tanto el `(` como el `)`. Antes
-        // `\(?` lo consumía fuera del grupo y un campo de una sola línea quedaba en -1,
-        // tratándose como "pendiente" y perdiéndose al cambiar de clase.
-        let fieldRegexPatterns = [
-          // Patrón estándar: name = models.CharField(...)
-          `^\\s+(\\w+)\\s*=\\s*models\\.(\\w+)\\s*(\\(?.*)`
-        ];
-
-        // Añadir patrón para alias: name = m.CharField(...)
-        if (importAliases['models']) {
-          fieldRegexPatterns.push(`^\\s+(\\w+)\\s*=\\s*${importAliases['models']}\\.(\\w+)\\s*(\\(?.*)`);
-        }
-
-        // Añadir patrón para importaciones directas: name = CharField(...)
-        if (directImports.length > 0) {
-          const directImportsPattern = directImports.join('|');
-          fieldRegexPatterns.push(`^\\s+(\\w+)\\s*=\\s*(${directImportsPattern})\\s*(\\(?.*)`);
-        }
-
-        // Intentar cada patrón
-        let fieldMatch = null;
-        let matchedPattern = '';
-        for (const pattern of fieldRegexPatterns) {
-          const regex = new RegExp(pattern);
+        // Intentar cada patrón (ya compilados fuera del bucle)
+        let fieldMatch: RegExpMatchArray | null = null;
+        for (const regex of fieldPatterns) {
           const match = line.match(regex);
           if (match) {
             fieldMatch = match;
-            matchedPattern = pattern;
             break;
           }
         }
@@ -414,18 +406,9 @@ export class DjangoProjectAnalyzer {
             });
           }
 
-          // Iniciar el seguimiento de un nuevo campo
+          // Iniciar el seguimiento de un nuevo campo. El tipo es siempre el grupo 2.
           currentFieldName = fieldMatch[1];
-
-          // El tipo de campo depende del patrón que coincidió
-          if (matchedPattern.includes('(\\w+)\\.(\\w+)')) {
-            // Patrón con prefijo (models.CharField o alias.CharField)
-            currentFieldType = fieldMatch[2];
-          } else {
-            // Patrón de importación directa (CharField)
-            currentFieldType = fieldMatch[2];
-          }
-
+          currentFieldType = fieldMatch[2];
           currentFieldLine = i;
           fieldStartIndentation = indentation;
 
@@ -587,21 +570,54 @@ export class DjangoProjectAnalyzer {
       // Expresión regular para encontrar includes
       const includeRegex = /include\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*['"]([^'"]+)['"]\s*)?\)/;
 
+      // Routers DRF: router.register(r'prefix', SomeViewSet[, ...]) (caso DRF/#12).
+      const routerRegex = /\brouter\.register\s*\(\s*r?['"]([^'"]*)['"]\s*,\s*(\w+(?:\.\w+)*)/;
+      // Detecta el inicio de una llamada path()/re_path()/url() para unir continuaciones.
+      const urlCallStartRegex = /\b(?:re_path|path|url)\s*\(/;
+
       for (let i = 0; i < lines.length; i++) {
+        // Unir continuaciones cuando una llamada path()/re_path()/url() abre
+        // paréntesis sin cerrarlos en la misma línea (definiciones multilínea).
+        let logicalLine = lines[i];
+        const startLine = i;
+        if (urlCallStartRegex.test(logicalLine)) {
+          let parenDepth =
+            (logicalLine.match(/\(/g) || []).length - (logicalLine.match(/\)/g) || []).length;
+          let j = i;
+          while (parenDepth > 0 && j + 1 < lines.length) {
+            j++;
+            logicalLine += ' ' + lines[j].trim();
+            parenDepth +=
+              (lines[j].match(/\(/g) || []).length - (lines[j].match(/\)/g) || []).length;
+          }
+          i = j; // saltar las líneas ya consumidas
+        }
+
         // Buscar patrones de URL directos
-        let match = lines[i].match(pathRegex) || lines[i].match(rePathRegex) || lines[i].match(urlRegex);
+        let match = logicalLine.match(pathRegex) || logicalLine.match(rePathRegex) || logicalLine.match(urlRegex);
         if (match) {
           const pattern = prefix + match[1];
           urls.push({
             pattern: pattern,
             viewName: match[2],
-            lineNumber: i
+            lineNumber: startLine
+          });
+          continue;
+        }
+
+        // Buscar registros de routers DRF (router.register).
+        const routerMatch = logicalLine.match(routerRegex);
+        if (routerMatch) {
+          urls.push({
+            pattern: prefix + routerMatch[1],
+            viewName: routerMatch[2],
+            lineNumber: startLine
           });
           continue;
         }
 
         // Buscar includes
-        const includeMatch = lines[i].match(includeRegex);
+        const includeMatch = logicalLine.match(includeRegex);
         if (includeMatch) {
           const includedModule = includeMatch[1];
           const includePrefix = includeMatch[2] || '';
@@ -647,53 +663,69 @@ export class DjangoProjectAnalyzer {
 
     try {
       const content = await readFile(adminPath, 'utf8');
+      const lineOf = (index: number): number =>
+        content.substring(0, index).split('\n').length - 1;
 
-      // Buscar todas las clases de admin
-      const classRegex = /class\s+(\w+)\s*\(\s*(?:admin\.)?(\w+Admin|TabularInline|StackedInline)\s*\)/g;
-      let classMatch;
-      while ((classMatch = classRegex.exec(content)) !== null) {
-        const adminClass: DjangoAdminClass = {
-          name: classMatch[1],
-          lineNumber: content.substring(0, classMatch.index).split('\n').length - 1,
-          modelName: ''
-        };
+      // Clases ya asociadas a un modelo vía decorador, para no duplicarlas
+      // en el escaneo de clases.
+      const decoratedClasses = new Set<string>();
 
-        // Buscar el modelo asociado
-        const modelRegex = new RegExp(`model\\s*=\\s*(\\w+)`, 'g');
-        const modelContent = content.substring(classMatch.index, content.length);
-        const modelMatch = modelRegex.exec(modelContent);
-        if (modelMatch) {
-          adminClass.modelName = modelMatch[1];
+      // Decoradores @admin.register(A, B, ...): admite varios modelos y
+      // decoradores apilados antes de la clase (se busca la primera `class` posterior).
+      const decoratorRegex = /@admin\.register\s*\(([^)]*)\)/g;
+      let decoratorMatch: RegExpExecArray | null;
+      while ((decoratorMatch = decoratorRegex.exec(content)) !== null) {
+        const models = decoratorMatch[1]
+          .split(',')
+          .map(m => m.trim())
+          .filter(Boolean);
+        const classAfter = content.substring(decoratorMatch.index).match(/\bclass\s+(\w+)\s*\(/);
+        if (classAfter && models.length > 0) {
+          decoratedClasses.add(classAfter[1]);
+          adminClasses.push({
+            name: classAfter[1],
+            lineNumber: lineOf(decoratorMatch.index),
+            modelName: models.join(', ')
+          });
         }
-
-        adminClasses.push(adminClass);
       }
 
-      // Buscar registros directos con admin.site.register
-      const registerRegex = /admin\.site\.register\s*\(\s*(\w+)(?:\s*,\s*(\w+))?\s*\)/g;
-      let registerMatch;
-      while ((registerMatch = registerRegex.exec(content)) !== null) {
-        const modelName = registerMatch[1];
-        const adminClassName = registerMatch[2] || 'ModelAdmin';
+      // Clases de admin declaradas: ModelAdmin, inlines o herencia custom (*Admin).
+      const classRegex = /class\s+(\w+)\s*\(\s*([\w.]+)\s*\)/g;
+      let classMatch: RegExpExecArray | null;
+      while ((classMatch = classRegex.exec(content)) !== null) {
+        const className = classMatch[1];
+        const baseName = classMatch[2].split('.').pop() || classMatch[2];
+        const isAdminBase =
+          /Admin$/.test(baseName) ||
+          baseName === 'TabularInline' ||
+          baseName === 'StackedInline';
+        if (!isAdminBase || decoratedClasses.has(className)) {
+          continue;
+        }
+
+        // Buscar `model = X` SOLO dentro del cuerpo de esta clase (hasta el
+        // siguiente `class` en columna 0 o el final del archivo), no en todo el resto.
+        const restAfter = content.substring(classMatch.index + classMatch[0].length);
+        const nextClass = restAfter.search(/\nclass\s/);
+        const body = nextClass >= 0 ? restAfter.substring(0, nextClass) : restAfter;
+        const modelMatch = body.match(/\bmodel\s*=\s*(\w+)/);
 
         adminClasses.push({
-          name: adminClassName,
-          lineNumber: content.substring(0, registerMatch.index).split('\n').length - 1,
-          modelName: modelName
+          name: className,
+          lineNumber: lineOf(classMatch.index),
+          modelName: modelMatch ? modelMatch[1] : ''
         });
       }
 
-      // Buscar decoradores de register
-      const decoratorRegex = /@admin\.register\s*\(\s*(\w+)\s*\)\s*\n+\s*class\s+(\w+)/g;
-      let decoratorMatch;
-      while ((decoratorMatch = decoratorRegex.exec(content)) !== null) {
-        const modelName = decoratorMatch[1];
-        const adminClassName = decoratorMatch[2];
-
+      // Registros directos: admin.site.register(Model, AdminClass?).
+      const registerRegex = /admin\.site\.register\s*\(\s*(\w+)(?:\s*,\s*(\w+))?\s*\)/g;
+      let registerMatch: RegExpExecArray | null;
+      while ((registerMatch = registerRegex.exec(content)) !== null) {
         adminClasses.push({
-          name: adminClassName,
-          lineNumber: content.substring(0, decoratorMatch.index).split('\n').length - 1,
-          modelName: modelName
+          name: registerMatch[2] || 'ModelAdmin',
+          lineNumber: lineOf(registerMatch.index),
+          modelName: registerMatch[1]
         });
       }
 
@@ -735,25 +767,21 @@ export class DjangoProjectAnalyzer {
             value = value.substring(0, commentIndex).trim();
           }
 
-          // Manejar valores multilínea
-          if ((value.includes('{') && !value.includes('}')) ||
-              (value.includes('[') && !value.includes(']')) ||
-              (value.includes('(') && !value.includes(')'))) {
+          // Manejar valores multilínea contando el BALANCE de brackets (corchetes,
+          // llaves y paréntesis). Antes se cortaba en el primer cierre encontrado, lo
+          // que rompía estructuras anidadas como DATABASES = { "default": { ... } }.
+          const countOpen = (s: string): number => (s.match(/[[{(]/g) || []).length;
+          const countClose = (s: string): number => (s.match(/[\]})]/g) || []).length;
+          let depth = countOpen(value) - countClose(value);
 
-            // Buscar el final de la definición multilínea
+          if (depth > 0) {
             let j = i + 1;
             let multilineValue = value;
 
-            while (j < lines.length) {
+            while (j < lines.length && depth > 0) {
               const nextLine = lines[j].trim();
               multilineValue += ' ' + nextLine;
-
-              if ((value.includes('{') && nextLine.includes('}')) ||
-                  (value.includes('[') && nextLine.includes(']')) ||
-                  (value.includes('(') && nextLine.includes(')'))) {
-                break;
-              }
-
+              depth += countOpen(nextLine) - countClose(nextLine);
               j++;
             }
 

--- a/src/djangoProjectAnalyzer.ts
+++ b/src/djangoProjectAnalyzer.ts
@@ -273,6 +273,7 @@ export class DjangoProjectAnalyzer {
       let inModelDefinition = false;
       let inMetaClass = false;
       let classIndentation = 0;
+      let metaIndentation = 0; // Indentación de la línea `class Meta:`
       let fieldStartIndentation = 0;
       let currentFieldName = '';
       let currentFieldType = '';
@@ -328,8 +329,16 @@ export class DjangoProjectAnalyzer {
         // Detectar si estamos entrando en la clase Meta
         if (line.match(metaClassRegex)) {
           inMetaClass = true;
+          metaIndentation = indentation;
           isPropertyMethod = false;
           continue;
+        }
+
+        // Salir de la clase Meta al volver a un nivel de indentación igual o menor
+        // al de `class Meta:` (p. ej. un campo declarado tras Meta, caso #11).
+        // Antes inMetaClass solo se reseteaba al cambiar de clase, perdiendo esos campos.
+        if (inMetaClass && line.trim() !== '' && indentation <= metaIndentation) {
+          inMetaClass = false;
         }
 
         // Si la indentación es menor o igual a la de la clase, hemos salido del modelo
@@ -362,20 +371,24 @@ export class DjangoProjectAnalyzer {
         }
 
         // Construir expresión regular para detectar campos considerando alias e importaciones directas
+        // El último grupo captura el paréntesis de apertura (`\(?` DENTRO del grupo),
+        // de modo que el conteo de paréntesis cuente tanto el `(` como el `)`. Antes
+        // `\(?` lo consumía fuera del grupo y un campo de una sola línea quedaba en -1,
+        // tratándose como "pendiente" y perdiéndose al cambiar de clase.
         let fieldRegexPatterns = [
           // Patrón estándar: name = models.CharField(...)
-          `^\\s+(\\w+)\\s*=\\s*models\\.(\\w+)\\s*\\(?(.*)`
+          `^\\s+(\\w+)\\s*=\\s*models\\.(\\w+)\\s*(\\(?.*)`
         ];
 
         // Añadir patrón para alias: name = m.CharField(...)
         if (importAliases['models']) {
-          fieldRegexPatterns.push(`^\\s+(\\w+)\\s*=\\s*${importAliases['models']}\\.(\\w+)\\s*\\(?(.*)`);
+          fieldRegexPatterns.push(`^\\s+(\\w+)\\s*=\\s*${importAliases['models']}\\.(\\w+)\\s*(\\(?.*)`);
         }
 
         // Añadir patrón para importaciones directas: name = CharField(...)
         if (directImports.length > 0) {
           const directImportsPattern = directImports.join('|');
-          fieldRegexPatterns.push(`^\\s+(\\w+)\\s*=\\s*(${directImportsPattern})\\s*\\(?(.*)`);
+          fieldRegexPatterns.push(`^\\s+(\\w+)\\s*=\\s*(${directImportsPattern})\\s*(\\(?.*)`);
         }
 
         // Intentar cada patrón
@@ -453,7 +466,7 @@ export class DjangoProjectAnalyzer {
         // Nueva línea con la misma indentación que el nivel de campo, pero no es continuación
         else if (indentation === fieldStartIndentation && !line.trim().startsWith('#')) {
           // Verificar si es un nuevo campo con cualquier formato no capturado anteriormente
-          const otherFieldRegex = /^\s+(\w+)\s*=\s*(\w+)(?:\.(\w+))?\s*\(?(.*)/;
+          const otherFieldRegex = /^\s+(\w+)\s*=\s*(\w+)(?:\.(\w+))?\s*(\(?.*)/;
           const otherFieldMatch = line.match(otherFieldRegex);
 
           if (otherFieldMatch) {
@@ -565,9 +578,11 @@ export class DjangoProjectAnalyzer {
       const lines = content.split('\n');
 
       // Expresiones regulares para encontrar patrones de URL
-      const pathRegex = /path\s*\(\s*['"]([^'"]+)['"]\s*,\s*(\w+(?:\.\w+)*)/;
-      const rePathRegex = /re_path\s*\(\s*['"]([^'"]+)['"]\s*,\s*(\w+(?:\.\w+)*)/;
-      const urlRegex = /url\s*\(\s*['"]([^'"]+)['"]\s*,\s*(\w+(?:\.\w+)*)/;
+      // `r?` admite raw strings (r'...'/r"...") en re_path()/url() (caso #9).
+      // `[^'"]*` admite el patron vacio de la raiz del sitio: path('').
+      const pathRegex = /path\s*\(\s*r?['"]([^'"]*)['"]\s*,\s*(\w+(?:\.\w+)*)/;
+      const rePathRegex = /re_path\s*\(\s*r?['"]([^'"]*)['"]\s*,\s*(\w+(?:\.\w+)*)/;
+      const urlRegex = /url\s*\(\s*r?['"]([^'"]*)['"]\s*,\s*(\w+(?:\.\w+)*)/;
 
       // Expresión regular para encontrar includes
       const includeRegex = /include\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*['"]([^'"]+)['"]\s*)?\)/;

--- a/src/djangoStructureProvider.ts
+++ b/src/djangoStructureProvider.ts
@@ -2,12 +2,24 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { DjangoTreeItem } from './djangoTreeItem';
-import { DjangoProjectAnalyzer } from './djangoProjectAnalyzer';
+import { DjangoProjectAnalyzer, ModelField } from './djangoProjectAnalyzer';
+
+/**
+ * Comprueba de forma asíncrona si una ruta existe, sin bloquear el event loop.
+ */
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.promises.access(targetPath, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTreeItem> {
   private _onDidChangeTreeData: vscode.EventEmitter<DjangoTreeItem | undefined | null | void> = new vscode.EventEmitter<DjangoTreeItem | undefined | null | void>();
   readonly onDidChangeTreeData: vscode.Event<DjangoTreeItem | undefined | null | void> = this._onDidChangeTreeData.event;
-  
+
   private analyzer: DjangoProjectAnalyzer;
   private projectRoot: string | undefined;
 
@@ -33,10 +45,12 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
     if (!element) {
       // Root level - show main project structure
       return this.getProjectStructure();
-    } else if (element.contextValue === 'config') {
+    }
+
+    if (element.contextValue === 'config') {
       // Configuration group - show settings and main URLs
       const items: DjangoTreeItem[] = [];
-      
+
       // Add settings
       const settingsFiles = await this.analyzer.findSettingsFiles(this.projectRoot);
       if (settingsFiles.length > 0) {
@@ -74,7 +88,9 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
       }
 
       return items;
-    } else if (element.contextValue === 'apps') {
+    }
+
+    if (element.contextValue === 'apps') {
       // Applications group - show all apps
       const apps = await this.analyzer.findDjangoApps(this.projectRoot);
       return Promise.all(apps.map(app => {
@@ -89,30 +105,37 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
         appItem.iconPath = new vscode.ThemeIcon('package');
         return appItem;
       }));
-    } else if (element.contextValue === 'app') {
-      // Application level - show models, views, etc.
-      return this.getAppStructure(element.resourceUri!.fsPath);
-    } else if (element.contextValue === 'models') {
-      // Show models
-      return this.getModels(element.resourceUri!.fsPath);
-    } else if (element.contextValue === 'views') {
-      // Show views
-      return this.getViews(element.resourceUri!.fsPath);
-    } else if (element.contextValue === 'urls') {
-      // Show URLs
-      return this.getUrls(element.resourceUri!.fsPath);
-    } else if (element.contextValue === 'admin') {
-      // Show admin classes
-      return this.getAdminClasses(element.resourceUri!.fsPath);
-    } else if (element.contextValue === 'main-urls') {
-      // Show global URLs
-      return this.getUrls(element.resourceUri!.fsPath);
-    } else if (element.contextValue === 'settings') {
-      // Show settings variables
-      return this.getSettings(element.resourceUri!.fsPath);
-    } else if (element.contextValue === 'model') {
+    }
+
+    // Las ramas restantes requieren un resourceUri asociado.
+    // Guardamos contra resourceUri ausente en lugar de usar aserciones non-null.
+    const uriContexts = ['app', 'models', 'views', 'urls', 'admin', 'main-urls', 'settings'];
+    if (uriContexts.includes(element.contextValue ?? '')) {
+      if (!element.resourceUri) {
+        return [];
+      }
+      const fsPath = element.resourceUri.fsPath;
+      switch (element.contextValue) {
+        case 'app':
+          return this.getAppStructure(fsPath);
+        case 'models':
+          return this.getModels(fsPath);
+        case 'views':
+          return this.getViews(fsPath);
+        case 'urls':
+        case 'main-urls':
+          return this.getUrls(fsPath);
+        case 'admin':
+          return this.getAdminClasses(fsPath);
+        case 'settings':
+          return this.getSettings(fsPath);
+      }
+    }
+
+    if (element.contextValue === 'model') {
       return this.getModelFields(element);
     }
+
     return [];
   }
 
@@ -122,6 +145,7 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
       return undefined;
     }
 
+    // Chequeo síncrono acotado al número de raíces del workspace (habitualmente 1).
     for (const folder of workspaceFolders) {
       const managePyPath = path.join(folder.uri.fsPath, 'manage.py');
       if (fs.existsSync(managePyPath)) {
@@ -161,28 +185,29 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
     appsItem.iconPath = new vscode.ThemeIcon('layers');
     items.push(appsItem);
 
-    return this.sortItems(items);
+    // Los grupos raíz (Configuration, Applications) se devuelven en orden fijo
+    // e intencional; no se ordenan con el comparador de datos de usuario.
+    return items;
   }
 
   private sortItems(items: DjangoTreeItem[]): DjangoTreeItem[] {
     const sortOrder = vscode.workspace.getConfiguration('djangoStructureExplorer').get('sortOrder', 'alphabetical');
-    
+
     if (sortOrder === 'alphabetical') {
       return items.sort((a, b) => a.label.toString().localeCompare(b.label.toString()));
     } else if (sortOrder === 'alphabeticalDesc') {
       return items.sort((a, b) => b.label.toString().localeCompare(a.label.toString()));
     }
-    
+
     return items; // codeOrder - mantener el orden original
   }
 
   private async getAppStructure(appPath: string): Promise<DjangoTreeItem[]> {
     const items: DjangoTreeItem[] = [];
-    const appName = path.basename(appPath);
 
     // Models
     const modelsPath = path.join(appPath, 'models.py');
-    if (fs.existsSync(modelsPath)) {
+    if (await pathExists(modelsPath)) {
       const modelsItem = new DjangoTreeItem(
         'Models',
         vscode.TreeItemCollapsibleState.Collapsed,
@@ -200,7 +225,7 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
 
     // Views
     const viewsPath = path.join(appPath, 'views.py');
-    if (fs.existsSync(viewsPath)) {
+    if (await pathExists(viewsPath)) {
       const viewsItem = new DjangoTreeItem(
         'Views',
         vscode.TreeItemCollapsibleState.Collapsed,
@@ -218,7 +243,7 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
 
     // URLs
     const urlsPath = path.join(appPath, 'urls.py');
-    if (fs.existsSync(urlsPath)) {
+    if (await pathExists(urlsPath)) {
       const urlsItem = new DjangoTreeItem(
         'URLs',
         vscode.TreeItemCollapsibleState.Collapsed,
@@ -236,7 +261,7 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
 
     // Admin
     const adminPath = path.join(appPath, 'admin.py');
-    if (fs.existsSync(adminPath)) {
+    if (await pathExists(adminPath)) {
       const adminItem = new DjangoTreeItem(
         'Admin',
         vscode.TreeItemCollapsibleState.Collapsed,
@@ -257,21 +282,15 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
 
   private async getModels(modelsPath: string): Promise<DjangoTreeItem[]> {
     const models = await this.analyzer.extractModels(modelsPath);
-    console.log('Models found:', models.length);
-    
+
     const items = models.map(model => {
-      console.log(`Model: ${model.name}, Fields: ${model.fields?.length || 0}`);
-      if (model.fields) {
-        console.log('Model fields:', JSON.stringify(model.fields));
-      }
-      
       // Create a copy of fields to avoid reference issues
       const fieldsData = model.fields ? [...model.fields] : [];
-      
+
       const modelItem = new DjangoTreeItem(
         model.name,
-        fieldsData.length > 0 
-          ? vscode.TreeItemCollapsibleState.Collapsed 
+        fieldsData.length > 0
+          ? vscode.TreeItemCollapsibleState.Collapsed
           : vscode.TreeItemCollapsibleState.None,
         {
           command: 'djangoStructureExplorer.openFile',
@@ -282,14 +301,13 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
         'model'
       );
       modelItem.iconPath = new vscode.ThemeIcon('symbol-class');
-      
-      // Store model fields in the tree item for later access
+
       modelItem.tooltip = `Model: ${model.name}`;
       modelItem.description = `${fieldsData.length} fields`;
-      
-      // Store fields as custom data since we can't modify command directly
-      (modelItem as any).modelFields = fieldsData;
-      
+
+      // Almacenar los campos del modelo de forma tipada para acceso posterior
+      modelItem.modelFields = fieldsData;
+
       return modelItem;
     });
 
@@ -310,8 +328,8 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
         vscode.Uri.file(viewsPath),
         'view'
       );
-      viewItem.iconPath = view.isClass 
-        ? new vscode.ThemeIcon('symbol-class') 
+      viewItem.iconPath = view.isClass
+        ? new vscode.ThemeIcon('symbol-class')
         : new vscode.ThemeIcon('symbol-method');
       return viewItem;
     });
@@ -363,14 +381,18 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
   }
 
   private async getSettings(settingsDir: string): Promise<DjangoTreeItem[]> {
-    const settingsFiles = await this.analyzer.findSettingsFiles(this.projectRoot!);
+    if (!this.projectRoot) {
+      return [];
+    }
+
+    const settingsFiles = await this.analyzer.findSettingsFiles(this.projectRoot);
     if (settingsFiles.length === 0) {
       return [];
     }
-    
+
     const settingsPath = settingsFiles[0];
     const settings = await this.analyzer.extractSettings(settingsPath);
-    
+
     const items = settings.map(setting => {
       const settingItem = new DjangoTreeItem(
         setting.name,
@@ -392,28 +414,27 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
   }
 
   private async getModelFields(modelItem: DjangoTreeItem): Promise<DjangoTreeItem[]> {
-    // Get model fields stored in the tree item
-    const fields = (modelItem as any).modelFields || [];
-    const modelsPath = modelItem.resourceUri!.fsPath;
-    
-    // If no fields, try to get them again
+    if (!modelItem.resourceUri) {
+      return [];
+    }
+    const modelsPath = modelItem.resourceUri.fsPath;
+
+    // Campos almacenados de forma tipada en el item del árbol
+    let fields: ModelField[] = modelItem.modelFields ?? [];
+
+    // Si no hay campos, intentar extraerlos de nuevo (una sola vez)
     if (fields.length === 0) {
-      try {
-        // Try to extract the model again to get its fields
-        const models = await this.analyzer.extractModels(modelsPath);
-        const modelName = modelItem.label?.toString() || '';
-        const model = models.find(m => m.name === modelName);
-        
-        if (model && model.fields && model.fields.length > 0) {
-          (modelItem as any).modelFields = model.fields;
-          return this.getModelFields(modelItem);
-        }
-      } catch (error) {
-        console.error('Error al intentar obtener campos del modelo:', error);
+      const models = await this.analyzer.extractModels(modelsPath);
+      const modelName = modelItem.label?.toString() || '';
+      const model = models.find(m => m.name === modelName);
+
+      if (model && model.fields && model.fields.length > 0) {
+        modelItem.modelFields = model.fields;
+        fields = model.fields;
       }
     }
-    
-    return fields.map((field: any) => {
+
+    return fields.map((field) => {
       const fieldItem = new DjangoTreeItem(
         field.name,
         vscode.TreeItemCollapsibleState.None,
@@ -425,17 +446,16 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
         vscode.Uri.file(modelsPath),
         field.isProperty ? 'model-property' : 'model-field'
       );
-      
+
       // Usar un icono diferente para propiedades
       if (field.isProperty) {
         fieldItem.iconPath = new vscode.ThemeIcon('symbol-method');
       } else {
         fieldItem.iconPath = new vscode.ThemeIcon('symbol-field');
       }
-      
-      // Usar fieldType o type, dependiendo de cuál esté disponible
-      fieldItem.description = field.fieldType || field.type || 'Unknown';
-      fieldItem.tooltip = `${field.isProperty ? 'Propiedad' : 'Campo'}: ${field.name}\nTipo: ${field.fieldType || field.type || 'Unknown'}`;
+
+      fieldItem.description = field.fieldType || 'Unknown';
+      fieldItem.tooltip = `${field.isProperty ? 'Propiedad' : 'Campo'}: ${field.name}\nTipo: ${field.fieldType || 'Unknown'}`;
       return fieldItem;
     });
   }

--- a/src/djangoTreeItem.ts
+++ b/src/djangoTreeItem.ts
@@ -1,7 +1,13 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
+import { ModelField } from './djangoProjectAnalyzer';
 
 export class DjangoTreeItem extends vscode.TreeItem {
+  /**
+   * Campos del modelo asociados a este item (solo para items de tipo 'model').
+   * Tipado explícito en lugar del antiguo canal lateral `(item as any).modelFields`.
+   */
+  public modelFields?: ModelField[];
+
   constructor(
     public readonly label: string,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState,
@@ -11,9 +17,6 @@ export class DjangoTreeItem extends vscode.TreeItem {
   ) {
     super(label, collapsibleState);
     this.tooltip = this.label;
-    if (resourceUri) {
-      this.resourceUri = resourceUri;
-    }
     if (contextValue) {
       this.contextValue = contextValue;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,19 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
-import * as path from 'path';
 import { DjangoStructureProvider } from './djangoStructureProvider';
-import { DjangoTreeItem } from './djangoTreeItem';
 import { DjangoOutlineProvider } from './djangoOutlineProvider';
+
+/**
+ * Comprueba de forma asíncrona si una ruta existe, sin bloquear el event loop.
+ */
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.promises.access(targetPath, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export function activate(context: vscode.ExtensionContext) {
   const djangoStructureProvider = new DjangoStructureProvider();
@@ -14,7 +24,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.languages.registerDocumentSymbolProvider({ language: 'python', pattern: '**/*.py' }, djangoOutlineProvider),
     vscode.commands.registerCommand('djangoStructureExplorer.refresh', () => djangoStructureProvider.refresh()),
     vscode.commands.registerCommand('djangoStructureExplorer.openFile', async (filePath: string, lineNumber?: number) => {
-      if (!fs.existsSync(filePath)) {
+      if (!(await pathExists(filePath))) {
         vscode.window.showErrorMessage(`El archivo ${filePath} no existe.`);
         return;
       }

--- a/src/test/analyzer.test.ts
+++ b/src/test/analyzer.test.ts
@@ -97,5 +97,43 @@ describe('DjangoProjectAnalyzer — red de seguridad de parsing (Fase 4)', () =>
         assert.ok(names.includes(expected), `falta el setting ${expected}`);
       }
     });
+
+    it('[Fase 3] captura el valor completo de un dict anidado (balance de brackets)', async () => {
+      const settings = await analyzer.extractSettings(path.join(FIXTURES, 'settings.py'));
+      const databases = settings.find(s => s.name === 'DATABASES');
+      assert.ok(databases, 'falta el setting DATABASES');
+      // El valor debe incluir el dict anidado completo, no truncarse en el primer '}'.
+      assert.ok(databases!.value.includes('sqlite3'), 'el valor de DATABASES se truncó antes del motor');
+      assert.ok(databases!.value.trim().endsWith('}'), 'el valor de DATABASES no cerró el dict externo');
+    });
+  });
+
+  describe('Fase 3 — refinamiento de URLs y admin', () => {
+    it('[Fase 3] captura una ruta path() declarada en varias líneas', async () => {
+      const urls = await analyzer.extractUrls(path.join(FIXTURES, 'urls.py'));
+      const views = urls.map(u => u.viewName);
+      assert.ok(views.includes('views.contact'), 'falta la ruta path() multilínea');
+    });
+
+    it('[Fase 3] captura un router.register() de DRF', async () => {
+      const urls = await analyzer.extractUrls(path.join(FIXTURES, 'urls.py'));
+      const authors = urls.find(u => u.viewName === 'views.AuthorViewSet');
+      assert.ok(authors, 'falta el registro del router DRF');
+      assert.strictEqual(authors!.pattern, 'authors');
+    });
+
+    it('[Fase 3] asocia varios modelos a un @admin.register(A, B)', async () => {
+      const admins = await analyzer.extractAdminClasses(path.join(FIXTURES, 'admin.py'));
+      const shared = admins.find(a => a.name === 'SharedAdmin');
+      assert.ok(shared, 'falta SharedAdmin');
+      assert.strictEqual(shared!.modelName, 'Category, TimeStamped');
+    });
+
+    it('[Fase 3] no duplica una clase admin ya registrada por decorador', async () => {
+      const admins = await analyzer.extractAdminClasses(path.join(FIXTURES, 'admin.py'));
+      const articleAdmins = admins.filter(a => a.name === 'ArticleAdmin');
+      assert.strictEqual(articleAdmins.length, 1, 'ArticleAdmin no debería duplicarse');
+      assert.strictEqual(articleAdmins[0].modelName, 'Article');
+    });
   });
 });

--- a/src/test/analyzer.test.ts
+++ b/src/test/analyzer.test.ts
@@ -1,0 +1,101 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { DjangoProjectAnalyzer } from '../djangoProjectAnalyzer';
+
+// __dirname en runtime = <root>/out/test ; los fixtures viven en src/test (no se compilan).
+const FIXTURES = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixtures', 'criticalapp');
+
+describe('DjangoProjectAnalyzer — red de seguridad de parsing (Fase 4)', () => {
+  const analyzer = new DjangoProjectAnalyzer();
+
+  describe('extractModels', () => {
+    it('detecta los tres modelos, incluida la herencia de base abstracta', async () => {
+      const models = await analyzer.extractModels(path.join(FIXTURES, 'models.py'));
+      const names = models.map(m => m.name);
+      assert.deepStrictEqual(
+        new Set(names),
+        new Set(['TimeStamped', 'Category', 'Article'])
+      );
+    });
+
+    // [Fase 2 · conteo de parentesis] El regex usa `\(?` que consume el parentesis
+    // de apertura, asi que un campo de una sola linea queda con parenthesesCount = -1
+    // y se trata como "pendiente": solo se vuelca al coincidir el siguiente campo o
+    // en EOF. El ultimo campo antes de un cambio de clase a mitad de archivo se pierde
+    // (aqui, `updated` de TimeStamped). Se activara en RED->GREEN en Fase 2.
+    it('[Fase 2] captura todos los campos de un modelo a mitad de archivo', async () => {
+      const models = await analyzer.extractModels(path.join(FIXTURES, 'models.py'));
+      const ts = models.find(m => m.name === 'TimeStamped');
+      const fieldNames = (ts?.fields ?? []).map(f => f.name);
+      assert.ok(fieldNames.includes('created'), 'falta el campo created');
+      assert.ok(fieldNames.includes('updated'), 'falta el campo updated');
+    });
+
+    it('captura campos estandar, multilinea y @property de Article', async () => {
+      const models = await analyzer.extractModels(path.join(FIXTURES, 'models.py'));
+      const article = models.find(m => m.name === 'Article');
+      const fieldNames = (article?.fields ?? []).map(f => f.name);
+      for (const expected of ['title', 'summary', 'body', 'category']) {
+        assert.ok(fieldNames.includes(expected), `falta el campo ${expected}`);
+      }
+    });
+
+    // [Fase 2 · #11] Un campo declarado DESPUES de la clase Meta se pierde porque
+    // inMetaClass no se resetea por indentacion. Se activara en RED->GREEN en Fase 2.
+    it('[Fase 2 #11] captura un campo declarado tras la clase Meta', async () => {
+      const models = await analyzer.extractModels(path.join(FIXTURES, 'models.py'));
+      const category = models.find(m => m.name === 'Category');
+      const fieldNames = (category?.fields ?? []).map(f => f.name);
+      assert.ok(fieldNames.includes('slug'), 'el campo slug declarado tras Meta deberia detectarse');
+    });
+  });
+
+  describe('extractUrls', () => {
+    it('captura una ruta path() con vista CBV .as_view()', async () => {
+      const urls = await analyzer.extractUrls(path.join(FIXTURES, 'urls.py'));
+      const patterns = urls.map(u => u.pattern);
+      assert.ok(patterns.includes('about/'), 'falta la ruta about/');
+    });
+
+    // [Fase 2 · #9] Las raw strings r'...' en re_path() no se reconocen.
+    it("[Fase 2 #9] captura re_path() con raw string r'...'", async () => {
+      const urls = await analyzer.extractUrls(path.join(FIXTURES, 'urls.py'));
+      const views = urls.map(u => u.viewName);
+      assert.ok(views.includes('views.year_archive'), 'falta la vista de re_path con raw string');
+    });
+
+    // [Fase 2 · #9] Las raw strings r'...' en url() no se reconocen.
+    it("[Fase 2 #9] captura url() con raw string r'...'", async () => {
+      const urls = await analyzer.extractUrls(path.join(FIXTURES, 'urls.py'));
+      const views = urls.map(u => u.viewName);
+      assert.ok(views.includes('views.legacy'), 'falta la vista de url con raw string');
+    });
+
+    // [Fase 2 · patron vacio] path('') de la raiz se ignora porque el regex exige [^'"]+.
+    it("[Fase 2] captura path('') de la raiz del sitio", async () => {
+      const urls = await analyzer.extractUrls(path.join(FIXTURES, 'urls.py'));
+      const views = urls.map(u => u.viewName);
+      assert.ok(views.includes('views.home'), 'falta la ruta raiz');
+    });
+  });
+
+  describe('extractAdminClasses', () => {
+    it('detecta todas las clases de admin declaradas', async () => {
+      const admins = await analyzer.extractAdminClasses(path.join(FIXTURES, 'admin.py'));
+      const names = admins.map(a => a.name);
+      for (const expected of ['ArticleAdmin', 'SharedAdmin', 'LegacyAdmin']) {
+        assert.ok(names.includes(expected), `falta la clase admin ${expected}`);
+      }
+    });
+  });
+
+  describe('extractSettings', () => {
+    it('detecta settings simples, de lista y de diccionario', async () => {
+      const settings = await analyzer.extractSettings(path.join(FIXTURES, 'settings.py'));
+      const names = settings.map(s => s.name);
+      for (const expected of ['SECRET_KEY', 'DEBUG', 'ALLOWED_HOSTS', 'INSTALLED_APPS', 'DATABASES']) {
+        assert.ok(names.includes(expected), `falta el setting ${expected}`);
+      }
+    });
+  });
+});

--- a/src/test/fixtures/criticalapp/admin.py
+++ b/src/test/fixtures/criticalapp/admin.py
@@ -1,10 +1,10 @@
 """Fixture de admin que cubre casos CRITICAL del parser.
 
 Casos cubiertos:
-- @admin.register(Model) decorador simple.
-- @admin.register(Model, OtroModel) decorador con varios modelos.
-- Clase admin con model = ... explicito.
-- admin.site.register(Model, AdminClass) registro directo.
+- Decorador de registro simple con un modelo.
+- Decorador de registro con varios modelos.
+- Clase admin con atributo de modelo explicito.
+- Registro directo en el sitio de administracion.
 """
 from django.contrib import admin
 

--- a/src/test/fixtures/criticalapp/admin.py
+++ b/src/test/fixtures/criticalapp/admin.py
@@ -1,0 +1,28 @@
+"""Fixture de admin que cubre casos CRITICAL del parser.
+
+Casos cubiertos:
+- @admin.register(Model) decorador simple.
+- @admin.register(Model, OtroModel) decorador con varios modelos.
+- Clase admin con model = ... explicito.
+- admin.site.register(Model, AdminClass) registro directo.
+"""
+from django.contrib import admin
+
+from .models import Category, Article, TimeStamped
+
+
+@admin.register(Article)
+class ArticleAdmin(admin.ModelAdmin):
+    list_display = ("title", "category")
+
+
+@admin.register(Category, TimeStamped)
+class SharedAdmin(admin.ModelAdmin):
+    pass
+
+
+class LegacyAdmin(admin.ModelAdmin):
+    model = Category
+
+
+admin.site.register(Category, LegacyAdmin)

--- a/src/test/fixtures/criticalapp/models.py
+++ b/src/test/fixtures/criticalapp/models.py
@@ -1,0 +1,42 @@
+"""Fixture de modelos que cubre casos CRITICAL del parser.
+
+Casos cubiertos:
+- Modelo base abstracto con clase Meta (herencia detectable en 2 pasadas).
+- Campo declarado DESPUES de la clase Meta (caso #11).
+- Comentario inline con parentesis que descuadra el conteo (caso #10).
+- Campo multilinea.
+- Metodo @property.
+"""
+from django.db import models
+
+
+class TimeStamped(models.Model):
+    created = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        abstract = True
+
+
+class Category(TimeStamped):
+    name = models.CharField(max_length=50)
+
+    class Meta:
+        verbose_name_plural = "Categories"
+        ordering = ["name"]
+
+    # Este campo se declara DESPUES de la clase Meta (caso #11).
+    slug = models.SlugField(unique=True)
+
+
+class Article(TimeStamped):
+    title = models.CharField(max_length=200)
+    summary = models.TextField(blank=True)  # resumen corto (ojo al ) del comentario)
+    body = models.TextField(
+        help_text="Texto completo del articulo (markdown soportado)",
+    )
+    category = models.ForeignKey(Category, on_delete=models.CASCADE)
+
+    @property
+    def is_long(self):
+        return len(self.body) > 1000

--- a/src/test/fixtures/criticalapp/settings.py
+++ b/src/test/fixtures/criticalapp/settings.py
@@ -1,0 +1,27 @@
+"""Fixture de settings que cubre casos CRITICAL del parser.
+
+Casos cubiertos:
+- Setting simple con comentario inline.
+- Setting booleano.
+- Setting de lista multilinea.
+- Setting de diccionario anidado multilinea.
+"""
+SECRET_KEY = "dev-key"  # no usar en produccion
+DEBUG = True
+
+ALLOWED_HOSTS = [
+    "localhost",
+    "127.0.0.1",
+]
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "criticalapp",
+]
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "db.sqlite3",
+    }
+}

--- a/src/test/fixtures/criticalapp/urls.py
+++ b/src/test/fixtures/criticalapp/urls.py
@@ -9,13 +9,22 @@ Casos cubiertos:
 """
 from django.urls import path, re_path, include
 from django.conf.urls import url
+from rest_framework import routers
 
 from . import views
+
+router = routers.DefaultRouter()
+router.register(r'authors', views.AuthorViewSet)
 
 urlpatterns = [
     path('', views.home, name='home'),
     path('about/', views.AboutView.as_view(), name='about'),
     re_path(r'^articles/(?P<year>[0-9]{4})/$', views.year_archive, name='year'),
     url(r'^legacy/$', views.legacy, name='legacy'),
+    path(
+        'contact/',
+        views.contact,
+        name='contact',
+    ),
     path('blog/', include('blog.urls')),
 ]

--- a/src/test/fixtures/criticalapp/urls.py
+++ b/src/test/fixtures/criticalapp/urls.py
@@ -1,0 +1,21 @@
+"""Fixture de URLs que cubre casos CRITICAL del parser.
+
+Casos cubiertos:
+- path('') de la raiz del sitio (patron vacio).
+- path() con vista CBV .as_view().
+- re_path() con raw string r'...' (caso #9).
+- url() con raw string r'...' (caso #9).
+- include() de otra app.
+"""
+from django.urls import path, re_path, include
+from django.conf.urls import url
+
+from . import views
+
+urlpatterns = [
+    path('', views.home, name='home'),
+    path('about/', views.AboutView.as_view(), name='about'),
+    re_path(r'^articles/(?P<year>[0-9]{4})/$', views.year_archive, name='year'),
+    url(r'^legacy/$', views.legacy, name='legacy'),
+    path('blog/', include('blog.urls')),
+]

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,26 @@
+/**
+ * Bootstrap de Mocha: intercepta require('vscode') con un stub minimo.
+ *
+ * El analizador importa 'vscode' solo para notificar errores
+ * (vscode.window.showErrorMessage). Fuera del host de extensiones ese modulo
+ * no existe, asi que lo sustituimos para poder ejecutar tests unitarios puros
+ * sin descargar el harness de Electron.
+ */
+import * as Module from 'module';
+
+const vscodeStub = {
+  window: {
+    showErrorMessage: (): undefined => undefined
+  }
+};
+
+const moduleRef = Module as unknown as {
+  _load: (request: string, parent: unknown, isMain: boolean) => unknown;
+};
+const originalLoad = moduleRef._load;
+moduleRef._load = function (request: string, parent: unknown, isMain: boolean): unknown {
+  if (request === 'vscode') {
+    return vscodeStub;
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};


### PR DESCRIPTION
## Resumen

Endurece el análisis del proyecto Django (basado en regex) en tres frentes: robustez/higiene de TypeScript, una red de seguridad de tests, y cobertura de los casos CRITICAL que el parser fallaba. Se añade además la primera infraestructura de tests del repo.

Tres commits atómicos:

1. **`c76d8c7` — Robustez (Fase 0+1)**
   - I/O síncrona (`fs.existsSync`) → `fs.promises.access` vía `pathExists` (no bloquea el event loop).
   - `getDirectories` acota profundidad (`MAX_DEPTH`) y excluye `venv`, `node_modules`, `site-packages`, `migrations`, etc.
   - Eliminado el canal lateral `(item as any).modelFields` → propiedad tipada `DjangoTreeItem.modelFields: ModelField[]`.
   - Guardas de `resourceUri`/`projectRoot` en vez de aserciones non-null.
   - Los `catch` notifican el fallo (`showErrorMessage`) en vez de devolver `[]` en silencio.
   - Eliminados los `console.log` de debug; imports no usados.

2. **`d147aa4` — Red de seguridad + cobertura CRITICAL (Fase 4 + Fase 2)**
   - Arnés **Mocha puro** que stubea `require('vscode')` (`src/test/setup.ts` + `.mocharc.json`), ejecutable sin el harness de Electron. Fixtures Django reales en `src/test/fixtures/criticalapp/`.
   - **Conteo de paréntesis**: el `(` de apertura pasa a estar dentro del grupo capturador; antes un campo de una sola línea quedaba en `-1` y se perdía el último campo de todo modelo intermedio.
   - **Raw strings**: `['"]` → `r?['"]` en `path`/`re_path`/`url`; `[^'"]+` → `[^'"]*` para admitir `path('')` de la raíz.
   - **Reset de `inMetaClass`** al desindentar al nivel de `class Meta:` (no se descartan campos declarados tras `Meta`).

3. **`57a2f39` — Refinamiento (Fase 3)**
   - Regex de campos compilado una sola vez fuera del bucle (perf).
   - admin: `@admin.register(A, B, …)` multi-modelo + decoradores apilados; herencia custom (`*Admin`); búsqueda de `model =` acotada al cuerpo de la clase; dedup.
   - urls: `path()`/`re_path()`/`url()` multilínea (unión por balance de paréntesis) y `router.register()` de DRF.
   - settings: valor multilínea por balance de brackets (antes truncaba dicts anidados como `DATABASES`).
   - `djangoOutlineProvider`: respeta `CancellationToken`.

## Limitaciones conocidas (fuera de alcance)

- El parser no ignora comentarios ni docstrings (limitación de fondo del enfoque 100% regex).
- `include()` con tuplas/variables y split-settings cross-file no se resuelven (requieren seguimiento de símbolos entre archivos).

## Plan de pruebas

- [x] `npm test` (compile + lint + mocha) → **15/15 en verde**.
- [x] `tsc -p ./` limpio.
- [x] `eslint src --ext ts` limpio.
- [ ] Verificación manual en VS Code: abrir un proyecto Django real y comprobar el árbol (modelos/campos, urls con raw strings, admin multi-modelo) y el outline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)