### PR TITLE
fix: evitar desbordamiento de pila en el recorrido de directorios (1.3.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "django-structure-explorer",
   "displayName": "Django Structure Explorer",
   "description": "PyCharm-style Django project structure explorer for VSCode",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "publisher": "Dos2Locos",
   "repository": {
     "type": "git",

--- a/src/djangoProjectAnalyzer.ts
+++ b/src/djangoProjectAnalyzer.ts
@@ -1613,7 +1613,12 @@ export class DjangoProjectAnalyzer {
           if (entry.name.startsWith('.') || EXCLUDED_DIRS.has(entry.name)) {
             continue;
           }
-          files.push(...await this.findTemplateFiles(fullPath, depth + 1));
+          // Acumular sin spread: `push(...arr)` se traduce en push.apply y, con
+          // miles de entradas, desborda el límite de argumentos del motor
+          // ("Maximum call stack size exceeded") en proyectos grandes.
+          for (const file of await this.findTemplateFiles(fullPath, depth + 1)) {
+            files.push(file);
+          }
         } else if (entry.isFile() && entry.name.endsWith('.html')) {
           files.push(fullPath);
         }
@@ -1658,9 +1663,13 @@ export class DjangoProjectAnalyzer {
         ) {
           dirs.push(fullPath);
 
-          // Recursivamente buscar en subdirectorios
+          // Recursivamente buscar en subdirectorios. Acumular sin spread:
+          // `push(...subdirs)` desborda el límite de argumentos del motor
+          // ("Maximum call stack size exceeded") cuando hay miles de directorios.
           const subdirs = await this.getDirectories(fullPath, depth + 1);
-          dirs.push(...subdirs);
+          for (const sub of subdirs) {
+            dirs.push(sub);
+          }
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Resumen

Corrige el error en tiempo de ejecución **"Maximum call stack size exceeded"** que vaciaba el árbol (`Django Structure Explorer: error inesperado.`) en proyectos grandes.

**Causa probable:** `getDirectories` y `findTemplateFiles` acumulaban resultados con `arr.push(...subArray)`. El spread se traduce en `push.apply`, y al superar el límite de argumentos del motor (~64–125k elementos) lanza "Maximum call stack size exceeded". Se sustituye por acumulación iterativa (`for ... push`), que no tiene ese límite.

> Nota de honestidad: no se dispone de stack trace, así que esto ataca la **causa más probable**, no un caso confirmado. Los recorridos siguen acotados por profundidad (`MAX_DEPTH`), así que no hay recursión infinita; el cambio es defensivo frente al volumen.

## Cambios
- `src/djangoProjectAnalyzer.ts`: spread-push → acumulación iterativa en `getDirectories` y `findTemplateFiles`.
- `package.json`: `1.3.0 → 1.3.1`.

## Plan de pruebas
- [x] `npm test` (compile + lint + 45 tests) en verde.
- [ ] Validación manual en un proyecto Django grande (F5 → Extension Development Host): expandir el árbol sin que aparezca el error.

## Notas
- No incluye el workflow de publicación (va en su propia PR).
- El parsing por regex se migrará a tree-sitter en un esfuerzo aparte; este fix es independiente (afecta al recorrido de FS, no al parsing).