### PR TITLE
ci: publicar en el Marketplace al fusionar PR a main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,69 @@
+name: Publish to VS Code Marketplace
+
+# Se ejecuta cuando se ACEPTA (fusiona) una PR contra main. El evento
+# pull_request:closed se dispara tanto al fusionar como al cerrar sin fusionar;
+# el `if` del job filtra para publicar solo cuando la PR se fusionó.
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      # Necesario para crear y empujar el tag de la versión publicada.
+      contents: write
+    steps:
+      - name: Checkout de main (incluye el merge y los tags)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Configurar Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Instalar dependencias
+        run: npm ci
+
+      - name: Compilar, lintar y testear
+        run: npm test
+
+      - name: Leer la versión del package.json
+        id: pkg
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Comprobar si la versión ya está publicada (tag existente)
+        id: check
+        env:
+          VERSION: ${{ steps.pkg.outputs.version }}
+        run: |
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Ya existe el tag v$VERSION; se omite la publicación."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publicar en el Marketplace
+        if: steps.check.outputs.exists == 'false'
+        run: npx --yes @vscode/vsce publish
+        env:
+          # PAT del publisher (Azure DevOps, scope Marketplace > Manage).
+          # Configúralo en Settings > Secrets and variables > Actions.
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Etiquetar la versión publicada
+        if: steps.check.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.pkg.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v$VERSION"
+          git push origin "v$VERSION"


### PR DESCRIPTION
## Resumen

Añade un workflow de GitHub Actions que publica la extensión en el VS Code Marketplace **cuando se fusiona (acepta) una PR contra `main`**.

## Cómo funciona
- **Disparador:** `pull_request` → `closed` sobre `main`, con `if: github.event.pull_request.merged == true` (solo al fusionar, no al cerrar sin fusionar).
- Checkout de `main` → Node 20 + `npm ci` → `npm test` (compile + lint + tests) → `@vscode/vsce publish`.
- **Guard anti-republicación:** lee la versión de `package.json`; si ya existe el tag `v<version>`, omite la publicación (no falla al fusionar PRs que no suben versión). Tras publicar, crea y empuja `v<version>`.
- Valores dinámicos pasados por `env:` (patrón seguro); no se usa ningún `github.event.*` no confiable en `run:`.

## Configuración requerida (antes del primer merge que deba publicar)
- **Secret `VSCE_PAT`**: Settings → Secrets and variables → Actions. PAT del publisher `Dos2Locos` (Azure DevOps, scope Marketplace → Manage).
- **Permisos de workflow**: Settings → Actions → General → Workflow permissions → *Read and write* (para empujar el tag).

## Notas
- Un workflow añadido en una PR **no** se ejecuta en el merge de esa misma PR (aún no está en `main`), así que **mergear esta PR no publica nada**.
- A partir de que esté en `main`, el siguiente merge de PR (p. ej. la #6, que sube a 1.3.1) publicará automáticamente.