### PR TITLE
feat: detección recursiva de la raíz y escaneo según .gitignore (+ fixes 1.4.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 .vscode-test/
 *.vsix
 .claude/
+# Logs locales de VS Code u otras herramientas: nunca deben commitearse
+# (pueden contener rutas/datos del proyecto) ni acabar en el .vsix.
+*.log

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,6 +12,9 @@ vsc-extension-quickstart.md
 .git/**
 .github/**
 **/*.vsix
+**/*.log
+out/test/**
+.mocharc.json
 **/tsconfig.json
 **/.eslintrc.json
 **/*.map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ y el proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 - **Exclusión de directorios según `.gitignore`.** Además de la lista por defecto
   de directorios pesados, el escaneo omite las carpetas declaradas en el
   `.gitignore` del proyecto. El parseo es conservador: solo nombres de directorio
-  inequívocos (sin globs, rutas anidadas ni negaciones). _(Idea de la PR #2 de
-  @0x3at.)_
+  inequívocos (sin globs, rutas anidadas ni negaciones). Se fusionan los
+  `.gitignore` de la raíz del workspace y del proyecto, de modo que en monorepos
+  con proyecto anidado (`manage.py` en `backend/`) se respeta el `.gitignore` de
+  la raíz del repositorio. _(Idea de la PR #2 de @0x3at.)_
 
 ### Corregido
 - `findMainUrlsFile` reconoce ahora los proyectos con **paquete de settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ Todas las novedades relevantes de la extensión se documentan en este archivo.
 El formato sigue [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/)
 y el proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [Sin publicar]
+
+### Añadido
+- **Localización recursiva de la raíz del proyecto.** Si `manage.py` no está en la
+  raíz del workspace (monorepos, proyectos en `backend/`, `src/`, `apps/api/`…),
+  ahora se busca hacia abajo en anchura y con profundidad acotada, omitiendo
+  directorios pesados (dependencias, entornos virtuales, cachés, ocultos). Antes
+  el árbol quedaba vacío en esos layouts. _(Idea tomada de la PR #2 de @0x3at,
+  reimplementada sobre el código actual.)_
+- **Exclusión de directorios según `.gitignore`.** Además de la lista por defecto
+  de directorios pesados, el escaneo omite las carpetas declaradas en el
+  `.gitignore` del proyecto. El parseo es conservador: solo nombres de directorio
+  inequívocos (sin globs, rutas anidadas ni negaciones). _(Idea de la PR #2 de
+  @0x3at.)_
+
+### Interno
+- Unificada la lista de directorios excluidos del escaneo en una única constante
+  (`DEFAULT_EXCLUDED_DIRS`), eliminando la duplicación entre `getDirectories` y
+  `findTemplateFiles`. Cobertura de tests para ambas mejoras.
+
 ## [1.4.1] - 2026-06-19
 
 ### Corregido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Todas las novedades relevantes de la extensión se documentan en este archivo.
 El formato sigue [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/)
 y el proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [1.4.1] - 2026-06-19
+
+### Corregido
+- `findMainUrlsFile` exige `settings.py` junto al `urls.py` para resolver el
+  URLconf raíz (no la primera app alfabética); las URLs traídas por `include()`
+  abren su fichero real. _(Porta el arreglo de @mvanorder, PR #3.)_
+
+### Interno
+- Saneado del paquete: se excluyen del `.vsix` los `*.log`, `out/test/` y
+  `.mocharc.json`, y se purga del repositorio un log local que se había colado.
+
 ## [1.4.0] - 2026-06-19
 
 ### Cambiado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ y el proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 - El parser ya no se rompe con imports que contienen metacaracteres de regex ni
   con valores de settings multilínea (heredado de la robustez previa, ahora
   garantizado por el AST).
+- `findMainUrlsFile` ya no devuelve el `urls.py` de la primera app en orden
+  alfabético: exige que el directorio contenga también `settings.py` (el paquete
+  de configuración). Al pinchar una URL traída por `include()` se abre su fichero
+  real, no el `urls.py` de cabecera. _(Porta el arreglo de @mvanorder, PR #3.)_
 
 ### Interno
 - Se registra el stacktrace completo en `reportError` y en `getChildren` para

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ y el proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/).
   inequívocos (sin globs, rutas anidadas ni negaciones). _(Idea de la PR #2 de
   @0x3at.)_
 
+### Corregido
+- `findMainUrlsFile` reconoce ahora los proyectos con **paquete de settings
+  dividido** (`config/settings/base.py`, `config/settings/prod.py`…): el nodo
+  Configuration > URLs ya no desaparece cuando no existe un `settings.py` plano
+  junto al `urls.py` raíz. _(Detectado en la revisión de Codex sobre la PR #9.)_
+
 ### Interno
 - Unificada la lista de directorios excluidos del escaneo en una única constante
   (`DEFAULT_EXCLUDED_DIRS`), eliminando la duplicación entre `getDirectories` y

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A Visual Studio Code extension that provides a PyCharm-like Django project struc
 
 - **Project Structure Tree View**: Quickly visualize your entire Django project structure
 - **Smart Django Detection**: Automatically identifies Django apps, models, views, and more
+- **Nested Project Root Detection**: Finds `manage.py` even when it lives in a subfolder (monorepos, projects under `backend/`, `src/`, `apps/api/`, …), not only at the workspace root
+- **`.gitignore`-Aware Scanning**: Skips heavy directories (dependencies, virtualenvs, caches) and also honors the folders declared in your project's `.gitignore`, keeping the tree focused on real source
 - **Model Field Explorer**: View detailed information about model fields and their types
 - **Admin Class Detection**: Navigate to admin classes and their associated models
 - **URL Patterns**: Explore URL patterns and their associated views
@@ -58,7 +60,7 @@ ext install Dos2Locos.django-structure-explorer
 ## Usage
 
 1. Open a Django project in VS Code
-2. The extension activates automatically when it detects a `manage.py` file
+2. The extension activates automatically when it detects a `manage.py` file (including one nested in a subfolder, e.g. `backend/manage.py`)
 3. Access the "Django Explorer" view in the Explorer sidebar
 4. Navigate through your Django project structure
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "django-structure-explorer",
   "displayName": "Django Structure Explorer",
   "description": "PyCharm-style Django project structure explorer for VSCode",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "publisher": "Dos2Locos",
   "repository": {
     "type": "git",

--- a/src/djangoProjectAnalyzer.ts
+++ b/src/djangoProjectAnalyzer.ts
@@ -59,6 +59,9 @@ export interface DjangoUrl {
   pattern: string;
   viewName: string;
   lineNumber: number;
+  // Fichero donde se declara esta URL. Difiere de la urls.py de cabecera cuando
+  // la ruta procede de un include(): así la navegación abre el fichero correcto.
+  filePath: string;
 }
 
 export interface DjangoAdminClass {
@@ -167,7 +170,9 @@ export class DjangoProjectAnalyzer {
     const dirs = await this.getDirectories(projectRoot);
     for (const dir of dirs) {
       const urlsPath = path.join(dir, 'urls.py');
-      if (await pathExists(urlsPath)) {
+      // El urls.py raíz vive en el paquete de configuración, junto a settings.py;
+      // así se evita devolver el urls.py de la primera app en orden alfabético.
+      if (await pathExists(urlsPath) && await pathExists(path.join(dir, 'settings.py'))) {
         // Verificar si es el urls.py principal (contiene ROOT_URLCONF o urlpatterns)
         const content = await readFile(urlsPath, 'utf8');
         if (content.includes('ROOT_URLCONF') || content.includes('urlpatterns')) {
@@ -530,7 +535,8 @@ export class DjangoProjectAnalyzer {
             urls.push({
               pattern: prefix + this.stringLiteralValue(patternNode),
               viewName: dottedName(viewNode),
-              lineNumber: call.startPosition.row
+              lineNumber: call.startPosition.row,
+              filePath: urlsPath
             });
           }
           continue;
@@ -545,7 +551,8 @@ export class DjangoProjectAnalyzer {
             urls.push({
               pattern: prefix + this.stringLiteralValue(patternNode),
               viewName: dottedName(viewNode),
-              lineNumber: call.startPosition.row
+              lineNumber: call.startPosition.row,
+              filePath: urlsPath
             });
           }
         }

--- a/src/djangoProjectAnalyzer.ts
+++ b/src/djangoProjectAnalyzer.ts
@@ -21,6 +21,18 @@ async function pathExists(targetPath: string): Promise<boolean> {
 }
 
 /**
+ * Directorios que el escaneo del proyecto omite siempre: dependencias, entornos
+ * virtuales, cachés y carpetas de build. Se exporta para que el localizador de
+ * la raíz (DjangoStructureProvider) reutilice la misma lista al descender en
+ * busca de manage.py. Los nombres con prefijo "." o "__" se filtran aparte.
+ */
+export const DEFAULT_EXCLUDED_DIRS: ReadonlySet<string> = new Set<string>([
+  'node_modules', 'venv', '.venv', 'env', 'site-packages',
+  '.git', '.tox', '.mypy_cache', '.pytest_cache', '__pycache__',
+  'migrations', 'build', 'dist', '.next', '.nuxt'
+]);
+
+/**
  * Registra un error y lo notifica al usuario, en lugar de tragárselo en silencio.
  * Así se distingue "no hay resultados" de "el parseo falló".
  */
@@ -145,6 +157,68 @@ export interface DjangoLocation {
 }
 
 export class DjangoProjectAnalyzer {
+
+  /** Nombres de directorio a ignorar, derivados del .gitignore del proyecto. */
+  private gitignoreDirs: Set<string> = new Set<string>();
+  /** Raíz para la que ya se cargó el .gitignore (evita relecturas en cada escaneo). */
+  private gitignoreLoadedFor?: string;
+
+  /**
+   * Carga, una sola vez por raíz, los nombres de directorio declarados en el
+   * .gitignore del proyecto para sumarlos a la exclusión del escaneo. Es
+   * conservador a propósito: solo considera entradas que nombran un directorio
+   * de forma inequívoca (sin globs, sin separadores de ruta intermedios y sin
+   * negaciones), de modo que la comparación por nombre no produzca falsos
+   * positivos. La ausencia o el fallo de lectura del fichero no es un error.
+   */
+  async loadIgnorePatterns(projectRoot: string): Promise<void> {
+    if (this.gitignoreLoadedFor === projectRoot) {
+      return;
+    }
+    this.gitignoreLoadedFor = projectRoot;
+    this.gitignoreDirs = new Set<string>();
+
+    const gitignorePath = path.join(projectRoot, '.gitignore');
+    if (!(await pathExists(gitignorePath))) {
+      return;
+    }
+
+    try {
+      const content = await readFile(gitignorePath, 'utf8');
+      for (const rawLine of content.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        // Saltar líneas vacías, comentarios y reglas de negación.
+        if (!line || line.startsWith('#') || line.startsWith('!')) {
+          continue;
+        }
+        // Quitar la barra final que en .gitignore marca "esto es un directorio".
+        const entry = line.replace(/\/+$/, '');
+        // Solo nombres simples: descartar globs y rutas ancladas o anidadas.
+        if (!entry || entry.includes('/') || /[*?[\]]/.test(entry)) {
+          continue;
+        }
+        this.gitignoreDirs.add(entry);
+      }
+    } catch (error) {
+      // Un .gitignore ilegible no debe romper el escaneo del proyecto.
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`[DjangoStructureExplorer] No se pudo leer .gitignore en "${projectRoot}": ${message}`);
+    }
+  }
+
+  /**
+   * Indica si un directorio debe omitirse durante el escaneo: ocultos (.*),
+   * dunder (__pycache__, etc.), la lista por defecto de directorios pesados y
+   * los nombres derivados del .gitignore del proyecto.
+   */
+  private isScanExcludedDir(name: string): boolean {
+    return (
+      name.startsWith('.') ||
+      name.startsWith('__') ||
+      DEFAULT_EXCLUDED_DIRS.has(name) ||
+      this.gitignoreDirs.has(name)
+    );
+  }
 
   /**
    * Busca todos los archivos settings.py en el proyecto
@@ -1484,10 +1558,6 @@ export class DjangoProjectAnalyzer {
   private async findTemplateFiles(dir: string, depth: number = 0): Promise<string[]> {
     const files: string[] = [];
     const MAX_DEPTH = 8;
-    const EXCLUDED_DIRS = new Set<string>([
-      'node_modules', 'venv', '.venv', 'env', 'site-packages',
-      '.git', '.tox', '.mypy_cache', '.pytest_cache'
-    ]);
 
     if (depth > MAX_DEPTH) {
       return files;
@@ -1500,7 +1570,7 @@ export class DjangoProjectAnalyzer {
         const fullPath = path.join(dir, entry.name);
 
         if (entry.isDirectory()) {
-          if (entry.name.startsWith('.') || EXCLUDED_DIRS.has(entry.name)) {
+          if (this.isScanExcludedDir(entry.name)) {
             continue;
           }
           files.push(...await this.findTemplateFiles(fullPath, depth + 1));
@@ -1525,10 +1595,6 @@ export class DjangoProjectAnalyzer {
   private async getDirectories(dir: string, depth: number = 0): Promise<string[]> {
     const dirs: string[] = [];
     const MAX_DEPTH = 6;
-    const EXCLUDED_DIRS = new Set<string>([
-      'node_modules', 'venv', '.venv', 'env', 'site-packages',
-      '.git', '.tox', '.mypy_cache', '.pytest_cache', 'migrations'
-    ]);
 
     if (depth > MAX_DEPTH) {
       return dirs;
@@ -1540,12 +1606,7 @@ export class DjangoProjectAnalyzer {
       for (const entry of entries) {
         const fullPath = path.join(dir, entry.name);
 
-        if (
-          entry.isDirectory() &&
-          !entry.name.startsWith('.') &&
-          !entry.name.startsWith('__') &&
-          !EXCLUDED_DIRS.has(entry.name)
-        ) {
+        if (entry.isDirectory() && !this.isScanExcludedDir(entry.name)) {
           dirs.push(fullPath);
 
           // Recursivamente buscar en subdirectorios

--- a/src/djangoProjectAnalyzer.ts
+++ b/src/djangoProjectAnalyzer.ts
@@ -158,27 +158,44 @@ export interface DjangoLocation {
 
 export class DjangoProjectAnalyzer {
 
-  /** Nombres de directorio a ignorar, derivados del .gitignore del proyecto. */
+  /** Nombres de directorio a ignorar, derivados de los .gitignore del proyecto. */
   private gitignoreDirs: Set<string> = new Set<string>();
-  /** Raíz para la que ya se cargó el .gitignore (evita relecturas en cada escaneo). */
+  /** Clave (conjunto de raíces) ya cargada, para evitar relecturas en cada escaneo. */
   private gitignoreLoadedFor?: string;
 
   /**
-   * Carga, una sola vez por raíz, los nombres de directorio declarados en el
-   * .gitignore del proyecto para sumarlos a la exclusión del escaneo. Es
+   * Carga, una sola vez por conjunto de raíces, los nombres de directorio
+   * declarados en los .gitignore del proyecto para sumarlos a la exclusión del
+   * escaneo. Se aceptan varias raíces porque en monorepos con proyecto anidado
+   * (p. ej. `manage.py` en `backend/`) el `.gitignore` suele vivir en la raíz
+   * del workspace, no junto al proyecto; se leen ambos y se fusionan. Es
    * conservador a propósito: solo considera entradas que nombran un directorio
    * de forma inequívoca (sin globs, sin separadores de ruta intermedios y sin
    * negaciones), de modo que la comparación por nombre no produzca falsos
-   * positivos. La ausencia o el fallo de lectura del fichero no es un error.
+   * positivos. La ausencia o el fallo de lectura de un fichero no es un error.
    */
-  async loadIgnorePatterns(projectRoot: string): Promise<void> {
-    if (this.gitignoreLoadedFor === projectRoot) {
+  async loadIgnorePatterns(roots: string | string[]): Promise<void> {
+    const rootList = (typeof roots === 'string' ? [roots] : roots).filter(Boolean);
+    // Clave estable e independiente del orden de las raíces.
+    const cacheKey = [...new Set(rootList)].sort().join('\0');
+    if (this.gitignoreLoadedFor === cacheKey) {
       return;
     }
-    this.gitignoreLoadedFor = projectRoot;
-    this.gitignoreDirs = new Set<string>();
+    this.gitignoreLoadedFor = cacheKey;
 
-    const gitignorePath = path.join(projectRoot, '.gitignore');
+    const dirs = new Set<string>();
+    for (const root of new Set(rootList)) {
+      await this.collectGitignoreDirs(root, dirs);
+    }
+    this.gitignoreDirs = dirs;
+  }
+
+  /**
+   * Lee el `.gitignore` de `root` (si existe) y vuelca en `target` los nombres
+   * de directorio inequívocos. No lanza: un fichero ausente o ilegible se ignora.
+   */
+  private async collectGitignoreDirs(root: string, target: Set<string>): Promise<void> {
+    const gitignorePath = path.join(root, '.gitignore');
     if (!(await pathExists(gitignorePath))) {
       return;
     }
@@ -197,12 +214,12 @@ export class DjangoProjectAnalyzer {
         if (!entry || entry.includes('/') || /[*?[\]]/.test(entry)) {
           continue;
         }
-        this.gitignoreDirs.add(entry);
+        target.add(entry);
       }
     } catch (error) {
       // Un .gitignore ilegible no debe romper el escaneo del proyecto.
       const message = error instanceof Error ? error.message : String(error);
-      console.error(`[DjangoStructureExplorer] No se pudo leer .gitignore en "${projectRoot}": ${message}`);
+      console.error(`[DjangoStructureExplorer] No se pudo leer .gitignore en "${root}": ${message}`);
     }
   }
 

--- a/src/djangoProjectAnalyzer.ts
+++ b/src/djangoProjectAnalyzer.ts
@@ -238,15 +238,43 @@ export class DjangoProjectAnalyzer {
   }
 
   /**
+   * Indica si `dir` es el paquete de configuración del proyecto: contiene un
+   * `settings.py` plano o un paquete de settings dividido `settings/` (con al
+   * menos un módulo `.py`, p. ej. `config/settings/base.py`). Sirve para
+   * distinguir el `urls.py` raíz del de una app cualquiera.
+   */
+  private async isConfigPackage(dir: string): Promise<boolean> {
+    // Layout clásico: config/settings.py junto al urls.py raíz.
+    if (await pathExists(path.join(dir, 'settings.py'))) {
+      return true;
+    }
+    // Layout dividido: config/settings/{__init__,base,prod}.py (paquete o
+    // namespace package). Se acepta si la carpeta contiene algún módulo Python.
+    const settingsDir = path.join(dir, 'settings');
+    try {
+      const stat = await fs.promises.stat(settingsDir);
+      if (!stat.isDirectory()) {
+        return false;
+      }
+      const entries = await readdir(settingsDir, { withFileTypes: true });
+      return entries.some(entry => entry.isFile() && entry.name.endsWith('.py'));
+    } catch {
+      // settings/ no existe o no es accesible: no es el paquete de configuración.
+      return false;
+    }
+  }
+
+  /**
    * Busca el archivo urls.py principal del proyecto
    */
   async findMainUrlsFile(projectRoot: string): Promise<string | undefined> {
     const dirs = await this.getDirectories(projectRoot);
     for (const dir of dirs) {
       const urlsPath = path.join(dir, 'urls.py');
-      // El urls.py raíz vive en el paquete de configuración, junto a settings.py;
-      // así se evita devolver el urls.py de la primera app en orden alfabético.
-      if (await pathExists(urlsPath) && await pathExists(path.join(dir, 'settings.py'))) {
+      // El urls.py raíz vive en el paquete de configuración (junto a settings.py
+      // o a un paquete settings/ dividido); así se evita devolver el urls.py de
+      // la primera app en orden alfabético.
+      if (await pathExists(urlsPath) && await this.isConfigPackage(dir)) {
         // Verificar si es el urls.py principal (contiene ROOT_URLCONF o urlpatterns)
         const content = await readFile(urlsPath, 'utf8');
         if (content.includes('ROOT_URLCONF') || content.includes('urlpatterns')) {

--- a/src/djangoStructureProvider.ts
+++ b/src/djangoStructureProvider.ts
@@ -2,7 +2,58 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { DjangoTreeItem } from './djangoTreeItem';
-import { DjangoProjectAnalyzer, ModelField, DjangoApiEndpoint } from './djangoProjectAnalyzer';
+import { DjangoProjectAnalyzer, ModelField, DjangoApiEndpoint, DEFAULT_EXCLUDED_DIRS } from './djangoProjectAnalyzer';
+
+/**
+ * Busca, en anchura y con profundidad acotada, el primer directorio que contenga
+ * manage.py por debajo de `start`. Recorre en BFS porque la raíz del proyecto
+ * suele estar a uno o dos niveles, y omite directorios pesados (dependencias,
+ * entornos virtuales, cachés, ocultos) para no congelar VS Code en proyectos
+ * grandes. Es síncrono a propósito: se invoca desde el constructor y refresh().
+ *
+ * Función de módulo (sin dependencias de VS Code) para poder probarla de forma
+ * aislada con fixtures de disco.
+ */
+export function findManagePyDir(start: string, maxDepth = 4): string | undefined {
+  let frontier: string[] = [start];
+
+  for (let depth = 0; depth < maxDepth && frontier.length > 0; depth++) {
+    const next: string[] = [];
+
+    for (const dir of frontier) {
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        // Directorios sin permisos: se omiten sin interrumpir la búsqueda.
+        continue;
+      }
+
+      for (const entry of entries) {
+        if (!entry.isDirectory()) {
+          continue;
+        }
+        if (
+          entry.name.startsWith('.') ||
+          entry.name.startsWith('__') ||
+          DEFAULT_EXCLUDED_DIRS.has(entry.name)
+        ) {
+          continue;
+        }
+
+        const childDir = path.join(dir, entry.name);
+        if (fs.existsSync(path.join(childDir, 'manage.py'))) {
+          return childDir;
+        }
+        next.push(childDir);
+      }
+    }
+
+    frontier = next;
+  }
+
+  return undefined;
+}
 
 /**
  * Comprueba de forma asíncrona si una ruta existe, sin bloquear el event loop.
@@ -86,6 +137,10 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
     if (!projectRoot) {
       return [];
     }
+
+    // Afina el escaneo con los patrones del .gitignore antes de listar apps,
+    // settings o plantillas. Es idempotente por raíz, así que apenas cuesta.
+    await this.analyzer.loadIgnorePatterns(projectRoot);
 
     if (!element) {
       // Root level - show main project structure
@@ -212,9 +267,16 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
 
     // Chequeo síncrono acotado al número de raíces del workspace (habitualmente 1).
     for (const folder of workspaceFolders) {
+      // Caso habitual: manage.py vive en la propia raíz del workspace.
       const managePyPath = path.join(folder.uri.fsPath, 'manage.py');
       if (fs.existsSync(managePyPath)) {
         return folder.uri.fsPath;
+      }
+      // Caso monorepo / proyecto anidado: el workspace no es el padre directo de
+      // manage.py (p. ej. backend/, src/, apps/api/). Se busca hacia abajo.
+      const nested = findManagePyDir(folder.uri.fsPath);
+      if (nested) {
+        return nested;
       }
     }
 

--- a/src/djangoStructureProvider.ts
+++ b/src/djangoStructureProvider.ts
@@ -139,8 +139,15 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
     }
 
     // Afina el escaneo con los patrones del .gitignore antes de listar apps,
-    // settings o plantillas. Es idempotente por raíz, así que apenas cuesta.
-    await this.analyzer.loadIgnorePatterns(projectRoot);
+    // settings o plantillas. Se incluyen las raíces del workspace además de la
+    // del proyecto: en monorepos con proyecto anidado (manage.py en backend/) el
+    // .gitignore suele vivir en la raíz del workspace, no junto al proyecto.
+    // Es idempotente por conjunto de raíces, así que apenas cuesta.
+    const ignoreRoots = new Set<string>([projectRoot]);
+    for (const folder of vscode.workspace.workspaceFolders ?? []) {
+      ignoreRoots.add(folder.uri.fsPath);
+    }
+    await this.analyzer.loadIgnorePatterns([...ignoreRoots]);
 
     if (!element) {
       // Root level - show main project structure

--- a/src/djangoStructureProvider.ts
+++ b/src/djangoStructureProvider.ts
@@ -839,9 +839,10 @@ export class DjangoStructureProvider implements vscode.TreeDataProvider<DjangoTr
         {
           command: 'djangoStructureExplorer.openFile',
           title: 'Open URL',
-          arguments: [urlsPath, url.lineNumber]
+          // url.filePath puede diferir de urlsPath si la ruta viene de un include().
+          arguments: [url.filePath, url.lineNumber]
         },
-        vscode.Uri.file(urlsPath),
+        vscode.Uri.file(url.filePath),
         'url'
       );
       urlItem.description = url.viewName;

--- a/src/test/analyzer.test.ts
+++ b/src/test/analyzer.test.ts
@@ -248,6 +248,8 @@ describe('DjangoProjectAnalyzer — red de seguridad de parsing (Fase 4)', () =>
       const leaf = urls.find(u => u.viewName === 'views.b_list');
       assert.ok(leaf, 'falta la ruta hoja incluida desde b.urls');
       assert.strictEqual(leaf!.pattern, 'b/lista/', 'la ruta incluida debe llevar el prefijo del path() externo');
+      // Porta el fix de #3: una URL incluida apunta a SU fichero, no al de cabecera.
+      assert.ok(leaf!.filePath.endsWith(path.join('b', 'urls.py')), 'la URL incluida debe apuntar a su propio urls.py');
     });
   });
 

--- a/src/test/analyzer.test.ts
+++ b/src/test/analyzer.test.ts
@@ -1,6 +1,9 @@
 import * as assert from 'assert';
 import * as path from 'path';
-import { DjangoProjectAnalyzer } from '../djangoProjectAnalyzer';
+import * as os from 'os';
+import * as fs from 'fs';
+import { DjangoProjectAnalyzer, DEFAULT_EXCLUDED_DIRS } from '../djangoProjectAnalyzer';
+import { findManagePyDir } from '../djangoStructureProvider';
 
 // __dirname en runtime = <root>/out/test ; los fixtures viven en src/test (no se compilan).
 const FIXTURES = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixtures', 'criticalapp');
@@ -11,6 +14,9 @@ const FIXTURES_CELERY = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixt
 const FIXTURES_REST = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixtures', 'restapp');
 const FIXTURES_NAV = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixtures', 'navproj');
 const FIXTURES_DECORATED = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixtures', 'decoratedapp');
+const FIXTURES_NESTED = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixtures', 'nestedproj');
+const FIXTURES_DEEP = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixtures', 'deepproj');
+const FIXTURES_IGNORED_ROOT = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixtures', 'ignoredroot');
 
 describe('DjangoProjectAnalyzer — red de seguridad de parsing (Fase 4)', () => {
   const analyzer = new DjangoProjectAnalyzer();
@@ -427,6 +433,92 @@ describe('DjangoProjectAnalyzer — red de seguridad de parsing (Fase 4)', () =>
       const views = await analyzer.extractViews(path.join(FIXTURES_REST, 'views.py'));
       const stats = views.find(v => v.name === 'stats');
       assert.deepStrictEqual(stats?.decorators, ['api_view']);
+    });
+  });
+
+  // Localización recursiva de la raíz: manage.py puede vivir en un subdirectorio
+  // (monorepo, proyecto en backend/), no solo en la raíz del workspace.
+  describe('findManagePyDir — búsqueda recursiva de la raíz', () => {
+    it('encuentra manage.py en un subdirectorio anidado (no en la raíz)', () => {
+      const root = findManagePyDir(FIXTURES_NESTED);
+      assert.ok(root, 'debe localizar la raíz anidada');
+      assert.strictEqual(path.basename(root!), 'backend', 'manage.py vive en backend/');
+    });
+
+    it('no desciende a directorios excluidos (dist, node_modules, venv…)', () => {
+      // El único manage.py de este proyecto cuelga de dist/: debe ignorarse.
+      const root = findManagePyDir(FIXTURES_IGNORED_ROOT);
+      assert.strictEqual(root, undefined, 'no debe localizar un manage.py dentro de un directorio excluido');
+    });
+
+    it('respeta el límite de profundidad', () => {
+      // manage.py está a dos niveles (wrap/inner): con maxDepth=1 no se alcanza.
+      assert.strictEqual(findManagePyDir(FIXTURES_DEEP, 1), undefined, 'con profundidad 1 no debe encontrarlo');
+      const root = findManagePyDir(FIXTURES_DEEP);
+      assert.ok(root && path.basename(root) === 'inner', 'con la profundidad por defecto sí debe encontrarlo');
+    });
+
+    it('devuelve undefined si no hay manage.py bajo la raíz', () => {
+      // criticalapp es una app suelta, sin manage.py en su árbol.
+      assert.strictEqual(findManagePyDir(FIXTURES), undefined);
+    });
+  });
+
+  // Exclusión de directorios por .gitignore: el escaneo debe omitir las carpetas
+  // declaradas en el .gitignore del proyecto, además de la lista por defecto.
+  // El escenario se construye en un directorio temporal en runtime: un .gitignore
+  // versionado dentro de los fixtures haría que git ignorase el propio fixture.
+  describe('Exclusión por .gitignore', () => {
+    let tmpRoot: string;
+
+    before(() => {
+      tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dse-gitignore-'));
+      fs.writeFileSync(
+        path.join(tmpRoot, '.gitignore'),
+        // Mezcla deliberada: directorio simple, comentario, glob, negación y ruta
+        // anidada. Solo "secret_app" debe acabar en la lista de exclusión.
+        '# carpetas privadas\nsecret_app/\n*.log\n!keep_this\nnested/dir\n'
+      );
+      for (const app of ['realapp', 'secret_app']) {
+        const appDir = path.join(tmpRoot, app);
+        fs.mkdirSync(appDir, { recursive: true });
+        fs.writeFileSync(path.join(appDir, 'models.py'), 'from django.db import models\n');
+      }
+    });
+
+    after(() => {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    it('por defecto (sin cargar .gitignore) detecta también la app ignorada', async () => {
+      const local = new DjangoProjectAnalyzer();
+      const apps = await local.findDjangoApps(tmpRoot);
+      const names = apps.map(a => path.basename(a));
+      assert.ok(names.includes('realapp'), 'debe detectar la app real');
+      assert.ok(names.includes('secret_app'), 'sin cargar .gitignore, secret_app aún se detecta');
+    });
+
+    it('tras loadIgnorePatterns omite la carpeta declarada en .gitignore', async () => {
+      const local = new DjangoProjectAnalyzer();
+      await local.loadIgnorePatterns(tmpRoot);
+      const apps = await local.findDjangoApps(tmpRoot);
+      const names = apps.map(a => path.basename(a));
+      assert.ok(names.includes('realapp'), 'la app real debe seguir apareciendo');
+      assert.ok(!names.includes('secret_app'), 'secret_app/ está en .gitignore y debe excluirse');
+    });
+
+    it('loadIgnorePatterns es inocuo si el proyecto no tiene .gitignore', async () => {
+      const local = new DjangoProjectAnalyzer();
+      // FIXTURES_NAV no tiene .gitignore: no debe lanzar ni alterar la detección.
+      await local.loadIgnorePatterns(FIXTURES_NAV);
+      const apps = await local.findDjangoApps(FIXTURES_NAV);
+      assert.ok(apps.some(a => path.basename(a) === 'blog'), 'la app blog debe detectarse igual');
+    });
+
+    it('la lista por defecto cubre los directorios pesados habituales', () => {
+      for (const expected of ['node_modules', 'venv', '.git', '__pycache__', 'migrations']) {
+        assert.ok(DEFAULT_EXCLUDED_DIRS.has(expected), `${expected} debería estar excluido por defecto`);
+      }
     });
   });
 

--- a/src/test/analyzer.test.ts
+++ b/src/test/analyzer.test.ts
@@ -528,6 +528,32 @@ describe('DjangoProjectAnalyzer — red de seguridad de parsing (Fase 4)', () =>
       assert.ok(!names.includes('secret_app'), 'secret_app/ está en .gitignore y debe excluirse');
     });
 
+    it('fusiona el .gitignore de la raíz del workspace con la del proyecto anidado', async () => {
+      // Monorepo: .gitignore en la raíz del workspace, manage.py + apps en backend/.
+      const ws = fs.mkdtempSync(path.join(os.tmpdir(), 'dse-monorepo-'));
+      try {
+        fs.writeFileSync(path.join(ws, '.gitignore'), 'secret_app/\n');
+        const backend = path.join(ws, 'backend');
+        for (const app of ['realapp', 'secret_app']) {
+          const appDir = path.join(backend, app);
+          fs.mkdirSync(appDir, { recursive: true });
+          fs.writeFileSync(path.join(appDir, 'models.py'), 'from django.db import models\n');
+        }
+
+        const local = new DjangoProjectAnalyzer();
+        // El provider pasa [proyecto, raíz(es) del workspace]; aquí lo emulamos.
+        await local.loadIgnorePatterns([backend, ws]);
+        const names = (await local.findDjangoApps(backend)).map(a => path.basename(a));
+        assert.ok(names.includes('realapp'), 'la app real debe aparecer');
+        assert.ok(
+          !names.includes('secret_app'),
+          'la carpeta ignorada en el .gitignore de la raíz del workspace debe excluirse aun con proyecto anidado'
+        );
+      } finally {
+        fs.rmSync(ws, { recursive: true, force: true });
+      }
+    });
+
     it('loadIgnorePatterns es inocuo si el proyecto no tiene .gitignore', async () => {
       const local = new DjangoProjectAnalyzer();
       // FIXTURES_NAV no tiene .gitignore: no debe lanzar ni alterar la detección.

--- a/src/test/analyzer.test.ts
+++ b/src/test/analyzer.test.ts
@@ -14,6 +14,7 @@ const FIXTURES_CELERY = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixt
 const FIXTURES_REST = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixtures', 'restapp');
 const FIXTURES_NAV = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixtures', 'navproj');
 const FIXTURES_DECORATED = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixtures', 'decoratedapp');
+const FIXTURES_SPLIT = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixtures', 'splitsettings');
 const FIXTURES_NESTED = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixtures', 'nestedproj');
 const FIXTURES_DEEP = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixtures', 'deepproj');
 const FIXTURES_IGNORED_ROOT = path.resolve(__dirname, '..', '..', 'src', 'test', 'fixtures', 'ignoredroot');
@@ -433,6 +434,26 @@ describe('DjangoProjectAnalyzer — red de seguridad de parsing (Fase 4)', () =>
       const views = await analyzer.extractViews(path.join(FIXTURES_REST, 'views.py'));
       const stats = views.find(v => v.name === 'stats');
       assert.deepStrictEqual(stats?.decorators, ['api_view']);
+    });
+  });
+
+  // findMainUrlsFile debe reconocer el paquete de configuración aunque use un
+  // paquete de settings dividido (config/settings/base.py), no solo settings.py.
+  describe('findMainUrlsFile — paquetes de settings divididos', () => {
+    it('devuelve el urls.py del paquete config con settings/ dividido', async () => {
+      const local = new DjangoProjectAnalyzer();
+      const mainUrls = await local.findMainUrlsFile(FIXTURES_SPLIT);
+      assert.ok(mainUrls, 'debe encontrar el urls.py raíz pese a no haber settings.py plano');
+      assert.ok(
+        mainUrls!.replace(/\\/g, '/').endsWith('splitsettings/config/urls.py'),
+        'debe devolver config/urls.py, no el urls.py de la app'
+      );
+    });
+
+    it('no devuelve el urls.py de una app sin paquete de configuración', async () => {
+      const local = new DjangoProjectAnalyzer();
+      const mainUrls = await local.findMainUrlsFile(FIXTURES_SPLIT);
+      assert.ok(!mainUrls!.replace(/\\/g, '/').includes('blogapp'), 'blogapp/urls.py no es la raíz');
     });
   });
 

--- a/src/test/fixtures/deepproj/wrap/inner/manage.py
+++ b/src/test/fixtures/deepproj/wrap/inner/manage.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+if __name__ == "__main__":
+    pass

--- a/src/test/fixtures/ignoredroot/dist/pkg/manage.py
+++ b/src/test/fixtures/ignoredroot/dist/pkg/manage.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+if __name__ == "__main__":
+    pass

--- a/src/test/fixtures/nestedproj/backend/manage.py
+++ b/src/test/fixtures/nestedproj/backend/manage.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+if __name__ == "__main__":
+    pass

--- a/src/test/fixtures/nestedproj/dist/badpkg/manage.py
+++ b/src/test/fixtures/nestedproj/dist/badpkg/manage.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+if __name__ == "__main__":
+    pass

--- a/src/test/fixtures/splitsettings/blogapp/models.py
+++ b/src/test/fixtures/splitsettings/blogapp/models.py
@@ -1,0 +1,5 @@
+from django.db import models
+
+
+class Post(models.Model):
+    titulo = models.CharField(max_length=200)

--- a/src/test/fixtures/splitsettings/blogapp/urls.py
+++ b/src/test/fixtures/splitsettings/blogapp/urls.py
@@ -1,0 +1,5 @@
+from django.urls import path
+
+urlpatterns = [
+    path('', None),
+]

--- a/src/test/fixtures/splitsettings/config/settings/base.py
+++ b/src/test/fixtures/splitsettings/config/settings/base.py
@@ -1,0 +1,2 @@
+DEBUG = True
+ALLOWED_HOSTS = []

--- a/src/test/fixtures/splitsettings/config/urls.py
+++ b/src/test/fixtures/splitsettings/config/urls.py
@@ -1,0 +1,5 @@
+from django.urls import path, include
+
+urlpatterns = [
+    path('blog/', include('blogapp.urls')),
+]

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -8,10 +8,34 @@
  */
 import * as Module from 'module';
 
+// TreeItem mínimo: djangoTreeItem.ts hace `class DjangoTreeItem extends
+// vscode.TreeItem` en top-level, así que el stub debe exponer una clase real
+// para que el módulo (y quien lo importe) cargue fuera del host de extensiones.
+class TreeItemStub {
+  tooltip?: string;
+  contextValue?: string;
+  iconPath?: unknown;
+  constructor(public label: string, public collapsibleState?: number) {}
+}
+
+class EventEmitterStub {
+  event = (): void => undefined;
+  fire = (): void => undefined;
+  dispose = (): void => undefined;
+}
+
 const vscodeStub = {
   window: {
     showErrorMessage: (): undefined => undefined
-  }
+  },
+  workspace: {
+    workspaceFolders: undefined
+  },
+  TreeItem: TreeItemStub,
+  TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+  ThemeIcon: class { constructor(public id: string) {} },
+  EventEmitter: EventEmitterStub,
+  Uri: { file: (p: string): { fsPath: string } => ({ fsPath: p }) }
 };
 
 const moduleRef = Module as unknown as {


### PR DESCRIPTION
## Resumen

Trae a `main` el trabajo de la rama `post-1.4.0-fixes`: una mejora nueva en la detección del proyecto, más los arreglos ya publicados en la línea 1.4.1.

### Novedad principal — porta las ideas de la PR #2 de @0x3at (reimplementadas sobre el código actual)

- **Detección recursiva de la raíz**: se localiza `manage.py` aunque viva en un subdirectorio (monorepos, `backend/`, `src/`, `apps/api/`…) mediante una búsqueda BFS acotada en profundidad que omite directorios pesados. Antes el árbol quedaba vacío en esos layouts.
- **Escaneo según `.gitignore`**: además de la lista por defecto de directorios pesados, el escaneo omite las carpetas declaradas en el `.gitignore` del proyecto. Parseo conservador: solo nombres de directorio inequívocos (sin globs, rutas anidadas ni negaciones).
- **Limpieza DRY**: la exclusión duplicada se unifica en la constante `DEFAULT_EXCLUDED_DIRS`.

### Arreglos incluidos (línea 1.4.1, aún no en `main`)

- `findMainUrlsFile` exige `settings.py` junto al `urls.py` para resolver el URLconf raíz; las URLs traídas por `include()` abren su fichero real. _(Porta el arreglo de @mvanorder, PR #3.)_
- Saneado del paquete `.vsix`: se excluyen `*.log`, `out/test/` y `.mocharc.json`; se purga un log local colado en el repo.

## Cambios

- `src/djangoStructureProvider.ts`: función de módulo `findManagePyDir(start, maxDepth=4)` (BFS acotado, sin dependencias de VS Code para poder testearla aislada) usada como fallback en `findDjangoProjectRoot()`; carga de patrones de `.gitignore` antes de escanear.
- `src/djangoProjectAnalyzer.ts`: `loadIgnorePatterns()` idempotente por raíz, helper de exclusión unificado y `DEFAULT_EXCLUDED_DIRS` exportada.
- `README.md` / `CHANGELOG.md`: documentadas ambas mejoras (CHANGELOG bajo "Sin publicar").
- Tests + fixtures nuevos; stub de `vscode` ampliado para importar el provider en pruebas.

## Test plan

- [x] `npm test` → 55 passing (8 nuevos: búsqueda recursiva y exclusión por `.gitignore`)
- [x] `npm run compile` y lint sin errores
- [ ] Verificación manual en un proyecto con `manage.py` anidado (p. ej. `backend/manage.py`)
- [ ] Verificación manual de exclusión de una carpeta listada en `.gitignore`

## Notas

- **Versión**: el feature queda como "Sin publicar" en el CHANGELOG; al ser una feature correspondería un bump a **1.5.0** en el commit de release. No se toca `package.json` en este PR.
- La PR #2 original ya ha sido cerrada con un comentario de agradecimiento a @0x3at.